### PR TITLE
OPENJPA-2601 Correct element name for query hint in orm.xml parser

### DIFF
--- a/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/TestXMLPersistenceMetaDataParser.java
+++ b/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/TestXMLPersistenceMetaDataParser.java
@@ -23,6 +23,9 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.openjpa.kernel.QueryHints;
+import org.apache.openjpa.meta.QueryMetaData;
+import org.apache.openjpa.persistence.meta.MetamodelImpl;
 import org.apache.openjpa.persistence.test.SQLListenerTestCase;
 import javax.persistence.*;
 
@@ -161,7 +164,14 @@ public class TestXMLPersistenceMetaDataParser extends SQLListenerTestCase {
         em.close();
         
     }
-    
+
+    public void testQueryHintOrmXml() {
+        QueryMetaData[] meta = ((MetamodelImpl) emf.getMetamodel()).getRepository().getQueryMetaDatas();
+        assertEquals(1, meta.length);
+        assertEquals("Country1.literal", meta[0].getName());
+        assertEquals(1, meta[0].getHintKeys().length);
+        assertEquals(QueryHints.HINT_USE_LITERAL_IN_SQL, meta[0].getHintKeys()[0]);
+    }
 
     private void printArrayList(ArrayList aList) {
         Iterator itr = aList.iterator();

--- a/openjpa-persistence-jdbc/src/test/resources/org/apache/openjpa/persistence/orm.xml
+++ b/openjpa-persistence-jdbc/src/test/resources/org/apache/openjpa/persistence/orm.xml
@@ -22,6 +22,10 @@
  xsi:schemaLocation="http://java.sun.com/xml/ns/persistence/orm orm_1_0.xsd"
  version="1.0">
     <package>org.apache.openjpa.persistence</package>
+    <named-query name="Country1.literal">
+        <query>Select c from Country1 c where c.name = 'literal'</query>
+        <hint name="openjpa.hint.UseLiteralInSQL" value="true" />
+    </named-query>
     <entity class="Security1">
         <table name="SECURITY1" />
         <attributes>

--- a/openjpa-persistence/src/main/java/org/apache/openjpa/persistence/XMLPersistenceMetaDataParser.java
+++ b/openjpa-persistence/src/main/java/org/apache/openjpa/persistence/XMLPersistenceMetaDataParser.java
@@ -170,7 +170,7 @@ public class XMLPersistenceMetaDataParser
 
         _elems.put("named-query", QUERY);
         _elems.put("named-native-query", NATIVE_QUERY);
-        _elems.put("query-hint", QUERY_HINT);
+        _elems.put("hint", QUERY_HINT);
         _elems.put("query", QUERY_STRING);
 
         _elems.put("flush-mode", FLUSH_MODE);


### PR DESCRIPTION
As described in [OPENJPA-2601](https://issues.apache.org/jira/browse/OPENJPA-2601), the `hint` element in `orm.xml` is not correctly parsed. This PR provides a test case and the relevant correction to `XMLPersistenceMetaDataParser`.
