### PR TITLE
changed version of maven-jar-plugin to 3.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -840,7 +840,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.0.2</version>
                     <executions>
                         <execution>
                             <id>default-jar</id>


### PR DESCRIPTION
in order to avoid

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-jar-plugin:3.0.0:jar
(default-jar) on project openjpa-kernel: 
Error assembling JAR: Problem creating jar: Execution exception: Java heap space -> [Help 1]
```

see https://travis-ci.org/krichter722/openjpa/jobs/238035277 for an example and https://stackoverflow.com/questions/44293284/how-to-work-around-java-heap-space-during-jar-assembly-on-travis-ci-org?noredirect=1#comment75605199_44293284 for additional discussion