### PR TITLE
OPENJPA-2725 - fix ConcurrentModificationException during unrefed dependents cleanup

### DIFF
--- a/openjpa-kernel/src/main/java/org/apache/openjpa/kernel/BrokerImpl.java
+++ b/openjpa-kernel/src/main/java/org/apache/openjpa/kernel/BrokerImpl.java
@@ -2153,12 +2153,10 @@ public class BrokerImpl implements Broker, FindCallbacks, Cloneable, Serializabl
                 // mark for delete all elements in deref, otherwise in some situations it
                 // throws ConcurrentModificationException
                 statesMarkedForDelete.addAll(_derefCache);
-                if(statesMarkedForDelete.size()>0) {
-                    for (StateManagerImpl state: statesMarkedForDelete) {
-                        deleteDeref(state);
-                    }
+                for (StateManagerImpl state: statesMarkedForDelete) {
+                    deleteDeref(state);
                 }
-
+                
                 flushAdditions(transactional, reason);
             }
 

--- a/openjpa-kernel/src/main/java/org/apache/openjpa/kernel/BrokerImpl.java
+++ b/openjpa-kernel/src/main/java/org/apache/openjpa/kernel/BrokerImpl.java
@@ -2149,8 +2149,16 @@ public class BrokerImpl implements Broker, FindCallbacks, Cloneable, Serializabl
             // dependents
             _flags |= FLAG_DEREFDELETING;
             if (flush && _derefCache != null && !_derefCache.isEmpty()) {
-                for (Iterator<StateManagerImpl> itr = _derefCache.iterator(); itr.hasNext();)
-                    deleteDeref(itr.next());
+                Set<StateManagerImpl> statesMarkedForDelete = new HashSet<>();
+                // mark for delete all elements in deref, otherwise in some situations it
+                // throws ConcurrentModificationException
+                statesMarkedForDelete.addAll(_derefCache);
+                if(statesMarkedForDelete.size()>0) {
+                    for (StateManagerImpl state: statesMarkedForDelete) {
+                        deleteDeref(state);
+                    }
+                }
+
                 flushAdditions(transactional, reason);
             }
 


### PR DESCRIPTION
In some situations there are state elements in _derefCache HashSet causing ConcurrentModificationException because set has been modified during iteration. 
Copy all elements into another set and calling the same deleteDeref(StateManagerImpl sm) function.