### PR TITLE
[OPENJPA-2668] fix for execution of a CriteriaQuery leaking into CriteriaQuery state

### DIFF
--- a/openjpa-all/pom.xml
+++ b/openjpa-all/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-all</artifactId>

--- a/openjpa-examples/image-gallery/pom.xml
+++ b/openjpa-examples/image-gallery/pom.xml
@@ -27,7 +27,7 @@
   <parent>
       <groupId>org.apache.openjpa</groupId>
       <artifactId>openjpa-examples</artifactId>
-      <version>3.1.0</version>
+      <version>3.1.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.openjpa.openjpa-examples</groupId>

--- a/openjpa-examples/openbooks/pom.xml
+++ b/openjpa-examples/openbooks/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-examples</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.apache.openjpa.openjpa-examples</groupId>

--- a/openjpa-examples/pom.xml
+++ b/openjpa-examples/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-examples</artifactId>

--- a/openjpa-examples/simple/pom.xml
+++ b/openjpa-examples/simple/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-examples</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.apache.openjpa.openjpa-examples</groupId>

--- a/openjpa-features/pom.xml
+++ b/openjpa-features/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-features</artifactId>

--- a/openjpa-integration/daytrader/pom.xml
+++ b/openjpa-integration/daytrader/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-integration</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-integration-daytrader</artifactId>

--- a/openjpa-integration/examples/pom.xml
+++ b/openjpa-integration/examples/pom.xml
@@ -37,7 +37,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-integration</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-integration-examples</artifactId>

--- a/openjpa-integration/jmx/pom.xml
+++ b/openjpa-integration/jmx/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-integration</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-integration-jmx</artifactId>

--- a/openjpa-integration/pom.xml
+++ b/openjpa-integration/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-integration</artifactId>

--- a/openjpa-integration/slf4j/pom.xml
+++ b/openjpa-integration/slf4j/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-integration</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-integration-slf4j</artifactId>

--- a/openjpa-integration/tck/pom.xml
+++ b/openjpa-integration/tck/pom.xml
@@ -78,7 +78,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-integration</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-integration-tck</artifactId>

--- a/openjpa-integration/validation/pom.xml
+++ b/openjpa-integration/validation/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-integration</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-integration-validation</artifactId>

--- a/openjpa-jdbc/pom.xml
+++ b/openjpa-jdbc/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-jdbc</artifactId>

--- a/openjpa-jest/pom.xml
+++ b/openjpa-jest/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-jest</artifactId>

--- a/openjpa-kernel/pom.xml
+++ b/openjpa-kernel/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-kernel</artifactId>

--- a/openjpa-lib/pom.xml
+++ b/openjpa-lib/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-lib</artifactId>

--- a/openjpa-persistence-jdbc/pom.xml
+++ b/openjpa-persistence-jdbc/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-persistence-jdbc</artifactId>

--- a/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/criteria/TestCriteria.java
+++ b/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/criteria/TestCriteria.java
@@ -19,6 +19,8 @@
 
 package org.apache.openjpa.persistence.criteria;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -27,6 +29,7 @@ import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
+import javax.persistence.criteria.ParameterExpression;
 
 import org.apache.openjpa.persistence.OpenJPAEntityManager;
 import org.apache.openjpa.persistence.query.DomainObject;
@@ -645,6 +648,26 @@ public class TestCriteria extends SingleEMFTestCase {
         for (int i = 0; i < p.length; i += 2) {
             q.setParameter(p[i].toString(), p[i+1]);
         }
+    }
+
+    public void testInCriteriaWithCollection() {
+
+        OpenJPAEntityManager em = emf.createEntityManager();
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+
+        CriteriaQuery<Customer> criteria = builder.createQuery(Customer.class);
+        Root<Customer> root = criteria.from(Customer.class);
+        criteria.where(root.get("status").in(builder.parameter(Collection.class)));
+
+        TypedQuery<Customer> query = em.createQuery(criteria);
+        System.err.println(query);
+        for (ParameterExpression parameter : criteria.getParameters()) {
+            query.setParameter(parameter, Arrays.asList(1L, 2L));
+        }
+
+        assertEquals("SELECT * FROM Customer c WHERE c.status IN (:param)", criteria.toString());
+        query.getResultList();
+        assertEquals("SELECT * FROM Customer c WHERE c.status IN (:param)", criteria.toString());
     }
 }
 

--- a/openjpa-persistence-locking/pom.xml
+++ b/openjpa-persistence-locking/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-persistence-locking</artifactId>

--- a/openjpa-persistence/pom.xml
+++ b/openjpa-persistence/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-persistence</artifactId>

--- a/openjpa-persistence/src/main/java/org/apache/openjpa/persistence/criteria/Expressions.java
+++ b/openjpa-persistence/src/main/java/org/apache/openjpa/persistence/criteria/Expressions.java
@@ -1440,6 +1440,12 @@ class Expressions {
             this.e = (ExpressionImpl<T>)e;
         }
 
+        private Expressions.In<?> copy() {
+            In<?> in = new Expressions.In<>(this.e);
+            in._exps.addAll(this._exps);
+            return in;
+        }
+
         @Override
         public Expression<T> getExpression() {
             return e;
@@ -1468,7 +1474,11 @@ class Expressions {
         }
 
         @Override
-        org.apache.openjpa.kernel.exps.Expression toKernelExpression(
+        org.apache.openjpa.kernel.exps.Expression toKernelExpression(ExpressionFactory factory, CriteriaQueryImpl<?> q) {
+            return copy().toKernelExpression0(factory, q);
+        }
+
+        org.apache.openjpa.kernel.exps.Expression toKernelExpression0(
             ExpressionFactory factory, CriteriaQueryImpl<?> q) {
             org.apache.openjpa.kernel.exps.Expression inExpr = null;
             if (_exps.size() == 1) {

--- a/openjpa-project/pom.xml
+++ b/openjpa-project/pom.xml
@@ -39,7 +39,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>apache-openjpa</artifactId>

--- a/openjpa-slice/pom.xml
+++ b/openjpa-slice/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-slice</artifactId>

--- a/openjpa-tools/openjpa-fetch-statistics-was/pom.xml
+++ b/openjpa-tools/openjpa-fetch-statistics-was/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-tools</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-fetch-statistics-was</artifactId>

--- a/openjpa-tools/openjpa-fetch-statistics/pom.xml
+++ b/openjpa-tools/openjpa-fetch-statistics/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-tools</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-fetch-statistics</artifactId>

--- a/openjpa-tools/openjpa-maven-plugin/pom.xml
+++ b/openjpa-tools/openjpa-maven-plugin/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-tools</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/openjpa-tools/pom.xml
+++ b/openjpa-tools/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
 <!--        <relativePath>../pom.xml</relativePath>-->
     </parent>
 

--- a/openjpa-xmlstore/pom.xml
+++ b/openjpa-xmlstore/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa-xmlstore</artifactId>

--- a/openjpa/pom.xml
+++ b/openjpa/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>openjpa</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <name>OpenJPA Parent POM</name>
     <description>Apache OpenJPA implementation of JSR-338 JPA 2.1</description>
 
-    <version>3.1.0</version>
+    <version>3.1.1-SNAPSHOT</version>
 
     <properties>
         <java.class.version>1.8</java.class.version>
@@ -160,7 +160,7 @@
         <connection>scm:git:https://gitbox.apache.org/repos/asf/openjpa.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/openjpa.git</developerConnection>
         <url>https://gitbox.apache.org/repos/asf/openjpa.git</url>
-      <tag>3.1.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <modules>


### PR DESCRIPTION
for [OPENJPA-2668](https://issues.apache.org/jira/browse/OPENJPA-2668)
added copy method to Expressons.In and use that to return the expression
so that the original is not changed.

Not sure if there's a better way to do this. This is quite how can I say, simple?

This is the only Expression that I could find that dirties the original CriteriaQuery and I'm fairly convinced that this shouldn't happen. 

Prior to this fix, executing the test would change the query and replace the parameter with the hydrated parameter values.