### PR TITLE
OPENJPA-2668 fix for query execution leaking into CriteriaQuery

### DIFF
--- a/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/criteria/TestCriteria.java
+++ b/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/criteria/TestCriteria.java
@@ -19,6 +19,8 @@
 
 package org.apache.openjpa.persistence.criteria;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -27,6 +29,7 @@ import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
+import javax.persistence.criteria.ParameterExpression;
 
 import org.apache.openjpa.persistence.OpenJPAEntityManager;
 import org.apache.openjpa.persistence.query.DomainObject;
@@ -645,6 +648,26 @@ public class TestCriteria extends SingleEMFTestCase {
         for (int i = 0; i < p.length; i += 2) {
             q.setParameter(p[i].toString(), p[i+1]);
         }
+    }
+
+    public void testInCriteriaWithCollection() {
+
+        OpenJPAEntityManager em = emf.createEntityManager();
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+
+        CriteriaQuery<Customer> criteria = builder.createQuery(Customer.class);
+        Root<Customer> root = criteria.from(Customer.class);
+        criteria.where(root.get("status").in(builder.parameter(Collection.class)));
+
+        TypedQuery<Customer> query = em.createQuery(criteria);
+        System.err.println(query);
+        for (ParameterExpression parameter : criteria.getParameters()) {
+            query.setParameter(parameter, Arrays.asList(1L, 2L));
+        }
+
+        assertEquals("SELECT * FROM Customer c WHERE c.status IN (:param)", criteria.toString());
+        query.getResultList();
+        assertEquals("SELECT * FROM Customer c WHERE c.status IN (:param)", criteria.toString());
     }
 }
 

--- a/openjpa-persistence/src/main/java/org/apache/openjpa/persistence/criteria/Expressions.java
+++ b/openjpa-persistence/src/main/java/org/apache/openjpa/persistence/criteria/Expressions.java
@@ -1440,6 +1440,12 @@ class Expressions {
             this.e = (ExpressionImpl<T>)e;
         }
 
+        private Expressions.In<?> copy() {
+            In<?> in = new Expressions.In<>(this.e);
+            in._exps.addAll(this._exps);
+            return in;
+        }
+
         @Override
         public Expression<T> getExpression() {
             return e;
@@ -1468,7 +1474,11 @@ class Expressions {
         }
 
         @Override
-        org.apache.openjpa.kernel.exps.Expression toKernelExpression(
+        org.apache.openjpa.kernel.exps.Expression toKernelExpression(ExpressionFactory factory, CriteriaQueryImpl<?> q) {
+            return copy().toKernelExpression0(factory, q);
+        }
+
+        org.apache.openjpa.kernel.exps.Expression toKernelExpression0(
             ExpressionFactory factory, CriteriaQueryImpl<?> q) {
             org.apache.openjpa.kernel.exps.Expression inExpr = null;
             if (_exps.size() == 1) {


### PR DESCRIPTION
for [OPENJPA-2668](https://issues.apache.org/jira/browse/OPENJPA-2668)
added copy method to Expressons.In and use that to return the expression
so that the original is not changed.

Not sure if there's a better way to do this. This is quite how can I say, simple?

This is the only Expression that I could find that dirties the original CriteriaQuery and I'm fairly convinced that this shouldn't happen.

Prior to this fix, executing the test would change the query and replace the parameter with the hydrated parameter values.