### PR TITLE
[OPENJPA-2788] addressing issue with anonymous parameters

### DIFF
--- a/openjpa-persistence/src/main/java/org/apache/openjpa/persistence/criteria/CriteriaQueryImpl.java
+++ b/openjpa-persistence/src/main/java/org/apache/openjpa/persistence/criteria/CriteriaQueryImpl.java
@@ -224,18 +224,10 @@ class CriteriaQueryImpl<T> implements OpenJPACriteriaQuery<T>, AliasContext {
      * Registers the given parameter.
      */
     void registerParameter(ParameterExpressionImpl<?> p) {
-        for (Object k : _params.keySet()) {
-            if (p.paramEquals(k)) {
-                // If a named ParameterExpressin did already get registered
-                // with that exact name, then we do ignore it.
-                // If we do a query.setParameter("someParamName", Bla)
-                // then it must uniquely identify a Parameter.
-                return;
-            }
-        }
-
+        if (!_params.containsKey(p)) {
         p.setIndex(_params.size());
         _params.put(p, p.getJavaType());
+    }
     }
 
     @Override

--- a/openjpa-persistence/src/main/java/org/apache/openjpa/persistence/criteria/ParameterExpressionImpl.java
+++ b/openjpa-persistence/src/main/java/org/apache/openjpa/persistence/criteria/ParameterExpressionImpl.java
@@ -109,24 +109,10 @@ class ParameterExpressionImpl<T> extends ExpressionImpl<T>
             ? factory.newCollectionValuedParameter(paramKey, clzz)
             : factory.newParameter(paramKey, clzz);
 
-        int index = _name != null
-            ? findIndexWithSameName(q)
-            : _index;
+        int index = _name != null ? q.getParameterTypes().indexOf(this) : _index;
         param.setIndex(index);
 
         return param;
-    }
-
-    private int findIndexWithSameName(CriteriaQueryImpl<?> q) {
-        OrderedMap<Object, Class<?>> parameterTypes = q.getParameterTypes();
-        int i = 0;
-        for (Object k : parameterTypes.keySet()) {
-            if (paramEquals(k)) {
-                return i;
-            }
-            i++;
-        }
-        return -1;
     }
 
     @Override
@@ -139,7 +125,8 @@ class ParameterExpressionImpl<T> extends ExpressionImpl<T>
         return getJavaType();
     }
 
-    public boolean paramEquals(Object o) {
+    @Override
+    public boolean equals(Object o) {
         if (this == o)
             return true;
 
@@ -158,19 +145,20 @@ class ParameterExpressionImpl<T> extends ExpressionImpl<T>
         if (getParameterType() != ((ParameterExpressionImpl<?>) o).getParameterType() )
             return false;
 
-        return value != null ? value.equals(that.value) : that.value == null;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
+        if (_name == null && that._name == null) {
+            return super.equals(o);
+        } else {
+            return _name.equals(that._name);
         }
-        return false;
     }
 
     @Override
     public int hashCode() {
-        return super.hashCode();
+        int result = _name != null ? _name.hashCode() : 0;
+        if (_name == null) {
+            result = 31 * result + super.hashCode();
+        }
+        result = 31 * result + (getParameterType() != null ? getParameterType().hashCode() : 0);
+        return result;
     }
 }


### PR DESCRIPTION
So a slight adjustment to the hashcode and equals method of the ParameterExpression.

Not 100% sure it's right like this but it works.

I guess I'm not too familiar with the reason for the addition of the hashCode and equals in the first place.

The bottom line is that we must include in these hashCode and equals method the ability to handle the situation where the name is not specified.