### PR TITLE
[2.2.x] Fix Checkstyles EOL exceptions

### DIFF
--- a/openjpa-project/checkstyle.xml
+++ b/openjpa-project/checkstyle.xml
@@ -26,7 +26,9 @@
 	we can remove this file and remove the reference from the pom.xml -->
 
 <module name="Checker">
-	<module name="NewlineAtEndOfFile" />
+	<module name="NewlineAtEndOfFile">
+		<property name="lineSeparator" value="lf" />
+	</module>
 	<module name="TreeWalker">
 		<module name="FileContentsHolder" />
 		<module name="LineLength">


### PR DESCRIPTION
I tried to build 2.2.x and it failed with 201 checkstyle errors concerning missing EOL characters in all openjpa-lib .java files. Considering there aren't actually any missing EOL characters on those files, I am going to fix the issue by updating the checkstyle.xml with the EOL character. This change allowed the 2.2.x build to complete successfully in local runs.

Signed-off-by: Will Dazey <dazeydev.3@gmail.com>