### PR TITLE
[2.2.x] OPENJPA-2790: Convert build from SVN to GIT

### DIFF
--- a/openjpa-kernel/src/main/java/org/apache/openjpa/enhance/PCEnhancer.java
+++ b/openjpa-kernel/src/main/java/org/apache/openjpa/enhance/PCEnhancer.java
@@ -61,6 +61,7 @@ import org.apache.openjpa.lib.util.J2DoPrivHelper;
 import org.apache.openjpa.lib.util.Localizer;
 import org.apache.openjpa.lib.util.Options;
 import org.apache.openjpa.lib.util.Services;
+import org.apache.openjpa.lib.util.git.GitUtils;
 import org.apache.openjpa.lib.util.Localizer.Message;
 import org.apache.openjpa.meta.AccessCode;
 import org.apache.openjpa.meta.ClassMetaData;
@@ -180,7 +181,7 @@ public class PCEnhancer {
                     in.close();
                 }
             }
-            rev = Integer.parseInt(revisionProps.getProperty("openjpa.enhancer.revision"));
+            rev = GitUtils.convertGitInfoToPCEnhancerVersion(revisionProps.getProperty("openjpa.enhancer.revision"));
         } catch (Exception e) {
         }
         if (rev > 0) {

--- a/openjpa-lib/pom.xml
+++ b/openjpa-lib/pom.xml
@@ -96,17 +96,34 @@
                         <phase>compile</phase>
                         <configuration>
                             <target>
+                                <!-- SVN would have appended 'M' to the end of the revision number if there were
+                                     uncommitted changes.  Git doesn't do that, so we have to work a bit to
+                                     emulate that behavior.  -->
+                                <echo>Determining if there are uncommitted changes...</echo>
+                                <exec outputproperty="git.diff.exitval" resultproperty="diff.state" failonerror="false" failifexecutionfails="false" executable="git">
+                                    <arg line="diff --quiet HEAD" />
+                                </exec>
+                                <exec outputproperty="git.diff.cached.exitval" resultproperty="diff.state.cached" failonerror="false" failifexecutionfails="false" executable="git">
+                                    <arg line="diff --cached --quiet HEAD" />
+                                </exec>
+                                <condition property="uncommitted.changes" value="M" else="">
+                                    <or>
+                                        <equals arg1="${diff.state}" arg2="1"/>
+                                        <equals arg1="${diff.state.cached}" arg2="1"/>
+                                    </or>
+                                </condition>
+                                
                                 <echo>Getting the 'GIT' revision value</echo>
                                 <exec outputproperty="git.revision" failonerror="false" failifexecutionfails="false" executable="git">
-                                    <arg line="rev-parse --short HEAD" />
+                                    <arg line="rev-parse --short=7 HEAD" />
                                 </exec>
-                                <echo>Revision: ${git.revision}</echo>
+                                <echo>Revision: ${git.revision}${uncommitted.changes}</echo>
 
                                 <echo>Getting the 'PCEnhancer' revision value</echo>
                                 <exec outputproperty="pcenhancer.git.revision" failonerror="false" failifexecutionfails="false" executable="git" append="false">
-                                    <arg line="rev-parse --short HEAD:./../openjpa-kernel/src/main/java/org/apache/openjpa/enhance/PCEnhancer.java" />
+                                    <arg line="rev-parse --short=7 HEAD:./../openjpa-kernel/src/main/java/org/apache/openjpa/enhance/PCEnhancer.java" />
                                 </exec>
-                                <echo>openjpa.enhancer.revision=${pcenhancer.git.revision}</echo>
+                                <echo>openjpa.enhancer.revision=${pcenhancer.git.revision}${uncommitted.changes}</echo>
 
                                 <echo>OpenJPA version: ${project.version}</echo>
 
@@ -116,9 +133,9 @@
 
                                 <mkdir dir="${outdir}/META-INF" />
                                 <echo file="${outdir}/META-INF/org.apache.openjpa.revision.properties">
-revision.number=${git.revision}
+revision.number=${git.revision}${uncommitted.changes}
 openjpa.version=${project.version}
-openjpa.enhancer.revision=${pcenhancer.git.revision}
+openjpa.enhancer.revision=${pcenhancer.git.revision}${uncommitted.changes}
                                 </echo>
                             </target>
                         </configuration>

--- a/openjpa-lib/src/main/java/org/apache/openjpa/lib/util/git/GitUtils.java
+++ b/openjpa-lib/src/main/java/org/apache/openjpa/lib/util/git/GitUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.    
+ */
+
+package org.apache.openjpa.lib.util.git;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class GitUtils {
+    static final Pattern fullRevisionPattern = Pattern.compile("[0-9A-Fa-f]+(([Mm]+)?)");
+    static final Pattern revisionPattern = Pattern.compile("[0-9A-Fa-f]+");
+    
+    /**
+     *  A public worker method that takes the output from running the ant script in the pom.xml that
+     *  removes the trailing 'M' produced with builds that have uncommitted changes.
+     *  
+     *  For example: fef543bM to fef543b (267342907)
+     *  
+     *  @param gitinfo
+     *  @return The formatted int version, or -1 if gitinfo is null or unparsable.
+     */
+    public static int convertGitInfoToPCEnhancerVersion(String gitinfo) {
+        if (gitinfo == null || fullRevisionPattern.matcher(gitinfo).matches() == false) {
+            return -1;
+        }
+        
+        Matcher matcher = revisionPattern.matcher(gitinfo);
+        if (matcher.find()) {
+            return Integer.parseInt(matcher.group(), 16);
+        }
+        
+        return -1;
+    }
+}

--- a/openjpa-lib/src/test/java/org/apache/openjpa/lib/util/git/TestGitUtils.java
+++ b/openjpa-lib/src/test/java/org/apache/openjpa/lib/util/git/TestGitUtils.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.    
+ */
+
+package org.apache.openjpa.lib.util.git;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import junit.textui.TestRunner;
+
+public class TestGitUtils extends TestCase {
+    public TestGitUtils(String s) {
+        super(s);
+    }
+    
+    public void testNull() {
+        assertEquals(-1, GitUtils.convertGitInfoToPCEnhancerVersion(null));
+    }
+    
+    public void testBasic() {
+        long i = 0xBC614E;
+        assertEquals(i, GitUtils.convertGitInfoToPCEnhancerVersion("BC614E"));
+    }
+    
+    public void testBasic2() {
+        int i = 0xfef543b;
+        assertEquals(i, GitUtils.convertGitInfoToPCEnhancerVersion("fef543b"));
+    }
+    
+    public void testGoodTrailingString() {
+        long i = 0xBC614E;
+        assertEquals(i, GitUtils.convertGitInfoToPCEnhancerVersion("BC614Em"));
+        assertEquals(i, GitUtils.convertGitInfoToPCEnhancerVersion("BC614EM"));
+    }
+    
+    public void testBad() {
+        long i = 0xBC614E;
+        assertEquals(-1, GitUtils.convertGitInfoToPCEnhancerVersion(i + "BC614Ems"));
+        assertEquals(-1, GitUtils.convertGitInfoToPCEnhancerVersion("ZC614EM"));
+        assertEquals(-1, GitUtils.convertGitInfoToPCEnhancerVersion("ZC614E"));
+    }
+    
+    public static Test suite() {
+        return new TestSuite(TestGitUtils.class);
+    }
+    
+    public static void main(String[] args) {
+        TestRunner.run(suite());
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/OPENJPA-2790

This change ensures that git hashes have a length of 7 (observed different default lengths between different versions of git), and restores the "M" at the end of the revision number to signify "dirty" OpenJPA builds.