### PR TITLE
Fix primary keys and foreign keys not being reversed on Oracle

### DIFF
--- a/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/OracleDictionary.java
+++ b/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/OracleDictionary.java
@@ -940,7 +940,7 @@ public class OracleDictionary
             if (!DBIdentifier.isNull(schemaName))
                 setString(stmnt, idx++, convertSchemaCase(schemaName), null);
             if (!DBIdentifier.isNull(tableName))
-                setString(stmnt, idx++, convertSchemaCase(tableName), null);
+                setString(stmnt, idx++, convertSchemaCase(tableName.getUnqualifiedName()), null);
 
             setTimeouts(stmnt, conf, false);
             rs = stmnt.executeQuery();
@@ -1019,7 +1019,7 @@ public class OracleDictionary
             if (!DBIdentifier.isNull(schemaName))
                 setString(stmnt, idx++, convertSchemaCase(schemaName), null);
             if (!DBIdentifier.isNull(tableName))
-                setString(stmnt, idx++, convertSchemaCase(tableName), null);
+                setString(stmnt, idx++, convertSchemaCase(tableName.getUnqualifiedName()), null);
             setTimeouts(stmnt, conf, false);
             rs = stmnt.executeQuery();
             List<ForeignKey> fkList = new ArrayList<>();


### PR DESCRIPTION
Primary keys and foreign keys not being reversed when targeting a subset of the schemas on Oracle.

Using the HR demo database:

```
    var options = new Options();
    options.put("properties", "<location of persistence xml>");

    var configuration = new JDBCConfigurationImpl();
    Configurations.populateConfiguration(configuration, options);

    var generator = new SchemaGenerator(configuration);

    generator.generateSchemas(new DBIdentifier[]{
        DBIdentifier.newTable("HR.REGIONS"),
        DBIdentifier.newTable("HR.COUNTRIES"),
        DBIdentifier.newTable("HR.LOCATIONS"),
        DBIdentifier.newTable("HR.LOCATIONS"),
        DBIdentifier.newTable("HR.DEPARTMENTS"),
        DBIdentifier.newTable("HR.JOBS"),
        DBIdentifier.newTable("HR.EMPLOYEES"),
        DBIdentifier.newTable("HR.JOB_HISTORY"),
    });
```