### PR TITLE
[OPENJPA-2801] Kubernetes TCPRemoteCommitProvider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sudo: false
+language: java
+jdk:
+  - openjdk8
+cache:
+  bundler: false
+  cargo: false
+  directories:
+    - $HOME/.m2
+env:
+  global:
+  - MAVEN_OPTS="-Xmx4096M -Xss128M -XX:+CMSClassUnloadingEnabled -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify"
+install: travis_wait 30 mvn --show-version --quiet install -DskipTests=true
+script:
+  # invoker.streamLogs: we cannot access to log files through Travis web ui, so display everything in the console
+  - mvn --show-version verify -Dinvoker.streamLogs=true
+notifications:
+  email:
+    - ilgrosso@apache.org
+#    - dev@openjpa.apache.org

--- a/openjpa-kernel/src/main/java/org/apache/openjpa/event/DynamicTCPRemoteCommitProvider.java
+++ b/openjpa-kernel/src/main/java/org/apache/openjpa/event/DynamicTCPRemoteCommitProvider.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.openjpa.event;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.security.AccessController;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.stream.Collectors;
+import org.apache.openjpa.lib.util.J2DoPrivHelper;
+
+public abstract class DynamicTCPRemoteCommitProvider extends TCPRemoteCommitProvider {
+
+    private int _cacheDurationMillis = 30000;
+
+    public DynamicTCPRemoteCommitProvider() throws UnknownHostException {
+        super();
+    }
+
+    public int getCacheDurationMillis() {
+        return _cacheDurationMillis;
+    }
+
+    public void setCacheDurationMillis(final int _cacheDurationMillis) {
+        this._cacheDurationMillis = _cacheDurationMillis;
+    }
+
+    @Override
+    public final void setAddresses(final String names) throws UnknownHostException {
+        throw new UnknownHostException("Do not set Addresses on this instance; "
+                + "did you expect " + TCPRemoteCommitProvider.class.getSimpleName() + " ?");
+    }
+
+    @Override
+    public void endConfiguration() {
+        TcpAddressesUpdater updater = new TcpAddressesUpdater();
+        updater.run();
+
+        Timer timer = new Timer(true);
+        timer.scheduleAtFixedRate(updater, 0, _cacheDurationMillis);
+
+        super.endConfiguration();
+    }
+
+    protected abstract List<String> fetchDynamicAddresses();
+
+    private class TcpAddressesUpdater extends TimerTask {
+
+        @Override
+        public void run() {
+            List<String> dynamicAddresses = fetchDynamicAddresses();
+
+            _addressesLock.lock();
+            try {
+                String localhostAddress = InetAddress.getLocalHost().getHostAddress();
+
+                for (String dynamic : dynamicAddresses) {
+                    InetAddress tmpAddress = AccessController.doPrivileged(J2DoPrivHelper.getByNameAction(dynamic));
+
+                    if (localhostAddress.equals(dynamic)) {
+                        // This string matches the hostname for for ourselves, we
+                        // don't actually need to send ourselves messages.
+                        if (log.isTraceEnabled()) {
+                            log.trace(s_loc.get("tcp-address-asself", tmpAddress.getHostAddress() + ":" + _port));
+                        }
+                    } else {
+                        HostAddress podAddress = new HostAddress(dynamic);
+                        if (_addresses.contains(podAddress)) {
+                            if (log.isTraceEnabled()) {
+                                log.trace(s_loc.get("dyntcp-address-not-set",
+                                        podAddress.getAddress().getHostAddress() + ":" + podAddress.getPort()));
+                            }
+                        } else {
+                            _addresses.add(podAddress);
+
+                            if (log.isTraceEnabled()) {
+                                log.trace(s_loc.get("dyntcp-address-set",
+                                        podAddress.getAddress().getHostAddress() + ":" + podAddress.getPort()));
+                            }
+                        }
+                    }
+                }
+
+                List<HostAddress> toCloseAndRemove = _addresses.stream().
+                        filter(address -> !dynamicAddresses.contains(address.getAddress().getHostAddress())).
+                        collect(Collectors.toList());
+                toCloseAndRemove.forEach(address -> {
+                    address.close();
+                    _addresses.remove(address);
+
+                    if (log.isTraceEnabled()) {
+                        log.trace(s_loc.get("tcp-address-unset",
+                                address.getAddress().getHostAddress() + ":" + address.getPort()));
+                    }
+                });
+            } catch (Exception e) {
+                if (log.isErrorEnabled()) {
+                    log.error(s_loc.get("dyntcp-updater-error"), e);
+                }
+            } finally {
+                _addressesLock.unlock();
+            }
+        }
+    }
+}

--- a/openjpa-kernel/src/main/resources/org/apache/openjpa/event/localizer.properties
+++ b/openjpa-kernel/src/main/resources/org/apache/openjpa/event/localizer.properties
@@ -81,6 +81,9 @@ tcp-start-listener: Started listening for remote commit information on \
 	port "{0}".
 tcp-address-asself: Identified address of "{0}", which is equal to ourself.
 tcp-address-set: Configured to send to peer "{0}"
+dyntcp-address-not-set: Already configured to send to peer "{0}"
+dyntcp-address-unset: Removed peer "{0}"
+dyntcp-updater-error: Error while updating hosts
 tcp-received-event: Received event from peer "{0}"
 tcp-open-connection: Creating new socket connection to "{0}", using local port \
 	"{1}".

--- a/openjpa-kubernetes/pom.xml
+++ b/openjpa-kubernetes/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<!--
+    Please keep the project tag on one line to avoid confusing
+    the release plugin.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.openjpa</groupId>
+    <artifactId>openjpa-parent</artifactId>
+    <version>3.1.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>openjpa-kubernetes</artifactId>
+  <packaging>jar</packaging>
+  <name>OpenJPA Kubernetes</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.openjpa</groupId>
+      <artifactId>openjpa-kernel</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-server-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jmock</groupId>
+      <artifactId>jmock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jmock</groupId>
+      <artifactId>jmock-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/openjpa-kubernetes/src/main/java/org/apache/openjpa/event/kubernetes/KubernetesTCPRemoteCommitProvider.java
+++ b/openjpa-kubernetes/src/main/java/org/apache/openjpa/event/kubernetes/KubernetesTCPRemoteCommitProvider.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.openjpa.event.kubernetes;
+
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.openjpa.event.DynamicTCPRemoteCommitProvider;
+import org.apache.openjpa.lib.util.Localizer;
+
+public class KubernetesTCPRemoteCommitProvider extends DynamicTCPRemoteCommitProvider {
+
+    private static final Localizer s_loc = Localizer.forPackage(KubernetesTCPRemoteCommitProvider.class);
+
+    private String _namespace = "<namespace>";
+
+    private String _label = "<label>";
+
+    public KubernetesTCPRemoteCommitProvider() throws UnknownHostException {
+        super();
+    }
+
+    public String getNamespace() {
+        return _namespace;
+    }
+
+    public void setNamespace(final String namespace) {
+        this._namespace = namespace;
+    }
+
+    public String getLabel() {
+        return _label;
+    }
+
+    public void setLabel(final String label) {
+        this._label = label;
+    }
+
+    protected KubernetesClient kubernetesClient() throws KubernetesClientException {
+        return new DefaultKubernetesClient();
+    }
+
+    @Override
+    protected List<String> fetchDynamicAddresses() {
+        List<String> podIPs = new ArrayList<>();
+
+        try (KubernetesClient client = kubernetesClient()) {
+            podIPs.addAll(client.pods().inNamespace(_namespace).withLabel(_label).list().
+                    getItems().stream().
+                    map(pod -> pod.getStatus().getPodIP()).
+                    collect(Collectors.toList()));
+
+            if (log.isTraceEnabled()) {
+                log.trace(s_loc.get("kubernetestcp-pods", podIPs));
+            }
+        } catch (KubernetesClientException e) {
+            if (log.isFatalEnabled()) {
+                log.fatal(s_loc.get("kubernetestcp-error"), e);
+            }
+        }
+
+        return podIPs;
+    }
+}

--- a/openjpa-kubernetes/src/main/resources/org/apache/openjpa/event/kubernetes/localizer.properties
+++ b/openjpa-kubernetes/src/main/resources/org/apache/openjpa/event/kubernetes/localizer.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+kubernetestcp-error: Error while setting up Kubernetes client
+kubernetestcp-pods: Pods found

--- a/openjpa-kubernetes/src/test/java/org/apache/openjpa/event/kubernetes/KubernetesTCPRemoteCommitProviderTest.java
+++ b/openjpa-kubernetes/src/test/java/org/apache/openjpa/event/kubernetes/KubernetesTCPRemoteCommitProviderTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.openjpa.event.kubernetes;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodStatusBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import java.lang.reflect.Field;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.builder.ReflectionToStringBuilder;
+import org.apache.openjpa.event.TCPRemoteCommitProvider;
+import org.apache.openjpa.lib.conf.Configuration;
+import org.apache.openjpa.lib.log.SLF4JLogFactory;
+import org.jmock.Expectations;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class KubernetesTCPRemoteCommitProviderTest {
+
+    private static final String NAMESPACE = "ns1";
+
+    private static final String LABEL = "testKey";
+
+    @Rule
+    public JUnitRuleMockery context = new JUnitRuleMockery();
+
+    @Rule
+    public KubernetesServer server = new KubernetesServer(true, true);
+
+    private Pod pod1;
+
+    private Pod pod2;
+
+    private Pod pod3;
+
+    private Pod pod4;
+
+    @Before
+    public void setupKubernetes() {
+        KubernetesClient client = server.getClient();
+
+        pod1 = new PodBuilder().
+                withNewMetadata().
+                withName("pod1").
+                addToLabels(LABEL, "value1").
+                endMetadata().
+                withStatus(new PodStatusBuilder().withPodIP("1.1.1.1").build()).
+                build();
+        client.pods().inNamespace(NAMESPACE).create(pod1);
+
+        pod2 = new PodBuilder().
+                withNewMetadata().
+                withName("pod2").
+                addToLabels(LABEL, "value2").
+                endMetadata().
+                withStatus(new PodStatusBuilder().withPodIP("2.2.2.2").build()).
+                build();
+        client.pods().inNamespace(NAMESPACE).create(pod2);
+
+        pod3 = new PodBuilder().
+                withNewMetadata().
+                withName("pod3").
+                endMetadata().
+                withStatus(new PodStatusBuilder().withPodIP("3.3.3.3").build()).
+                build();
+        client.pods().inNamespace("ns2").create(pod3);
+
+        pod4 = new PodBuilder().
+                withNewMetadata().
+                withName("pod4").
+                addToLabels("other", "value1").
+                endMetadata().
+                withStatus(new PodStatusBuilder().withPodIP("4.4.4.4").build()).
+                build();
+        client.pods().inNamespace(NAMESPACE).create(pod4);
+
+        PodList podList = client.pods().inNamespace(NAMESPACE).withLabel(LABEL).list();
+        assertNotNull(podList);
+        assertEquals(2, podList.getItems().size());
+        assertTrue(podList.getItems().contains(pod1));
+        assertTrue(podList.getItems().contains(pod2));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> getAddresses(final KubernetesTCPRemoteCommitProvider rcp)
+            throws NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+
+        Field _addresses = TCPRemoteCommitProvider.class.getDeclaredField("_addresses");
+        _addresses.setAccessible(true);
+
+        return new ArrayList<>((List<Object>) _addresses.get(rcp)).stream().
+                map(ReflectionToStringBuilder::toString).
+                map(address -> StringUtils.substringAfter(address, "_address=/")).
+                map(address -> StringUtils.substringBefore(address, ",")).
+                collect(Collectors.toList());
+    }
+
+    @Test
+    public void addresses() throws UnknownHostException, NoSuchFieldException,
+            IllegalArgumentException, IllegalAccessException, InterruptedException {
+
+        // prepare KubernetesTCPRemoteCommitProvider instance, inject mocked Kubernetes client
+        KubernetesTCPRemoteCommitProvider rcp = new KubernetesTCPRemoteCommitProvider() {
+
+            @Override
+            protected KubernetesClient kubernetesClient() throws KubernetesClientException {
+                return server.getClient();
+            }
+        };
+        rcp.setNamespace(NAMESPACE);
+        rcp.setLabel(LABEL);
+        rcp.setCacheDurationMillis(500);
+
+        // mock OpenJPA configuration
+        Configuration conf = context.mock(Configuration.class);
+        context.checking(new Expectations() {
+
+            {
+                oneOf(conf).getLog(with(any(String.class)));
+                will(returnValue(new SLF4JLogFactory().getLog("")));
+            }
+        });
+        rcp.setConfiguration(conf);
+
+        // finalize
+        rcp.endConfiguration();
+
+        // expect to find remote addresses of matching pods
+        List<String> addresses = getAddresses(rcp);
+        assertEquals(2, addresses.size());
+        assertTrue(addresses.contains(pod1.getStatus().getPodIP()));
+        assertTrue(addresses.contains(pod2.getStatus().getPodIP()));
+
+        Thread.sleep(500);
+
+        addresses = getAddresses(rcp);
+        assertEquals(2, addresses.size());
+        assertTrue(addresses.contains(pod1.getStatus().getPodIP()));
+        assertTrue(addresses.contains(pod2.getStatus().getPodIP()));
+    }
+}

--- a/openjpa/pom.xml
+++ b/openjpa/pom.xml
@@ -83,6 +83,7 @@
                                     <include>org.apache.openjpa:openjpa-persistence-jdbc</include>
                                     <include>org.apache.openjpa:openjpa-xmlstore</include>
                                     <include>org.apache.openjpa:openjpa-slice</include>
+                                    <include>org.apache.openjpa:openjpa-kubernetes</include>
                                 </includes>
                             </artifactSet>
                             <!-- OpenJPA unique META-INF setup -->
@@ -232,6 +233,11 @@
         <dependency>
             <groupId>org.apache.openjpa</groupId>
             <artifactId>openjpa-slice</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.openjpa</groupId>
+            <artifactId>openjpa-kubernetes</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <mssql.connector.version>7.2.1</mssql.connector.version>
 
         <!-- other common versions -->
+        <kubernetes-client.version>4.7.0</kubernetes-client.version>
         <slf4j.version>1.7.23</slf4j.version>
         <!-- Compile Java source/target class level -->
         <compile.class.source>${java.class.version}</compile.class.source>
@@ -174,6 +175,7 @@
         <module>openjpa-xmlstore</module>
         <module>openjpa-slice</module>
         <module>openjpa-jest</module>
+        <module>openjpa-kubernetes</module>
         <module>openjpa</module>
         <module>openjpa-project</module>
         <module>openjpa-examples</module>
@@ -1788,6 +1790,16 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
                 <version>2.11.1</version>
+            </dependency>
+            <dependency>
+              <groupId>io.fabric8</groupId>
+              <artifactId>kubernetes-client</artifactId>
+              <version>${kubernetes-client.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>io.fabric8</groupId>
+              <artifactId>kubernetes-server-mock</artifactId>
+              <version>${kubernetes-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Working implementation - tested with GCP - of TCPRemoteCommitProvider powered by Kubernetes' client library to dynamically discover pods.

I am creating this PR for review: it also includes a working `.travis.yml` from my own fork that will be removed eventually before merge, given the [discussion](https://lists.apache.org/thread.html/82739677363b480e0913496ccd33e449625052e821f4b0275f6101c6%40%3Cdev.openjpa.apache.org%3E) we had on dev@.