### PR TITLE
* Fixed bad return value in DBDictionary.getMinorVersion()

### DIFF
--- a/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/DBDictionary.java
+++ b/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/DBDictionary.java
@@ -5999,7 +5999,7 @@ public class DBDictionary
 	 * Gets minor version of the database server.
 	 */
 	public final int getMinorVersion() {
-		return major;
+		return minor;
 	}
 
 	/**


### PR DESCRIPTION
In the method getMinorVersion() the returned value is "major" instead of "minor"