### PR TITLE
Fix SelectImpl#getColumnAlias in case of DBDictionary that use delimiters aggressively

### DIFF
--- a/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/SelectImpl.java
+++ b/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/SelectImpl.java
@@ -2711,7 +2711,7 @@ public class SelectImpl
                 return alias + "_" + col;
             }
             alias = SelectImpl.toAlias(_sel.getTableIndex(col.getTable(), pj, false));
-            return (alias == null) ? null : alias + "." + col;
+            return (alias == null) ? null : alias + "." + _sel._dict.getNamingUtil().toDBName(col.toString());
         }
 
         ////////////////////////////


### PR DESCRIPTION
This is a draft PR.
I am trying to run all of the integration tests against HerdDB.
HerdDBDictionary enables aggressive use of delimiters, in order to not have problems with the the long list of reserved words in Apache Calcite.

TestPersistence fails and I am suggesting this fix.
If the fix is correct, can you please suggest me where to add a test case ?

I am reopening #66, already reviewed by @struberg 