### PR TITLE
[OPENJPA-2828] Fix method equals()

### DIFF
--- a/openjpa-kernel/src/main/java/org/apache/openjpa/conf/Specification.java
+++ b/openjpa-kernel/src/main/java/org/apache/openjpa/conf/Specification.java
@@ -94,8 +94,8 @@ public class Specification {
         if (other == null || !this.getClass().isInstance(other))
             return false;
         Specification that = (Specification)other;
-        return Objects.equals(_name, this._name) && _major == that._major
-            && Objects.equals(_minor, this._minor);
+        return Objects.equals(_name, that._name) && _major == that._major
+            && Objects.equals(_minor, that._minor);
     }
 
     /**

--- a/openjpa-kernel/src/test/java/org/apache/openjpa/conf/SpecificationAdditionalTests.java
+++ b/openjpa-kernel/src/test/java/org/apache/openjpa/conf/SpecificationAdditionalTests.java
@@ -1,15 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package apache.openjpa;
 
-import org.junit.Before;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import static org.junit.Assert.*;
 import org.apache.openjpa.lib.meta.ClassMetaDataIterator;
 import org.apache.openjpa.meta.ClassMetaData;
-import org.apache.openjpa.util.UserException;
 import org.junit.Assert;
 import org.apache.openjpa.conf.*;
-
 
 public class SpecificationTest {
 

--- a/openjpa-kernel/src/test/java/org/apache/openjpa/conf/SpecificationAdditionalTests.java
+++ b/openjpa-kernel/src/test/java/org/apache/openjpa/conf/SpecificationAdditionalTests.java
@@ -27,7 +27,7 @@ import org.apache.openjpa.meta.ClassMetaData;
 import org.junit.Assert;
 import org.apache.openjpa.conf.*;
 
-public class SpecificationTest {
+public class SpecificationAdditionalTests {
 
 	String myString = "JPA";
 	String myCompleteString = "JPA 2.0-draft";

--- a/openjpa-kernel/src/test/java/org/apache/openjpa/conf/SpecificationAdditionalTests.java
+++ b/openjpa-kernel/src/test/java/org/apache/openjpa/conf/SpecificationAdditionalTests.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package apache.openjpa.conf;
+package org.apache.openjpa.conf;
 
 
 import org.junit.Test;

--- a/openjpa-kernel/src/test/java/org/apache/openjpa/conf/SpecificationAdditionalTests.java
+++ b/openjpa-kernel/src/test/java/org/apache/openjpa/conf/SpecificationAdditionalTests.java
@@ -1,0 +1,65 @@
+package apache.openjpa;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.junit.Assert.*;
+import org.apache.openjpa.lib.meta.ClassMetaDataIterator;
+import org.apache.openjpa.meta.ClassMetaData;
+import org.apache.openjpa.util.UserException;
+import org.junit.Assert;
+import org.apache.openjpa.conf.*;
+
+
+public class SpecificationTest {
+
+	String myString = "JPA";
+	String myCompleteString = "JPA 2.0-draft";
+	String myCompleteString2 = "JPA 2.1-draft";
+	String myHalfCompleteString = "JPA 2";
+	String myHalfCompleteString2 = "JPQ 2";
+	String myNullString = null;
+
+	
+	@Test
+	public void EqualsTest() { 
+		Specification spec = new Specification(myString);
+		Assert.assertTrue(spec.equals(spec)); // parse() is overidded in Specification
+	}
+
+	@Test
+	public void EqualsTest2() {
+		Specification spec = new Specification(myString);
+		Assert.assertFalse(spec.equals(myNullString)); // parse() is overidded in Specification
+	}
+		
+	
+	@Test 
+	public void EqualsTest3() { 
+		Specification spec = new Specification(myString);
+		Specification spec2 = new Specification(myHalfCompleteString);
+		Assert.assertFalse(spec.equals(spec2)); // parse() is overidded in Specification
+	}
+
+        @Test      
+	public void EqualsTest4() { 
+		Specification spec = new Specification(myString);
+		Assert.assertFalse(spec.equals(1)); // parse() is overidded in Specification
+	}
+	
+	@Test 
+	public void EqualsTest5() {  
+		Specification spec = new Specification(myHalfCompleteString);
+		Specification spec2 = new Specification(myHalfCompleteString2);
+		Assert.assertFalse(spec.equals(spec2)); 
+	}
+	
+	@Test 
+	public void EqualsTest6() { 
+		Specification spec = new Specification(myCompleteString);
+		Specification spec2 = new Specification(myHalfCompleteString2);
+		Assert.assertFalse(spec.equals(spec2)); 
+	}
+	
+	
+}

--- a/openjpa-kernel/src/test/java/org/apache/openjpa/conf/SpecificationAdditionalTests.java
+++ b/openjpa-kernel/src/test/java/org/apache/openjpa/conf/SpecificationAdditionalTests.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package apache.openjpa;
+package apache.openjpa.conf;
 
 
 import org.junit.Test;


### PR DESCRIPTION
Possible patch for ticket OPENJPA-2828  [JIRA ticket](https://issues.apache.org/jira/browse/OPENJPA-2828)
The method equals() should not returns true if the given Object and the receiver have different '_name' and '_minor'.

This can be a valid fix.
@gulyx 