### PR TITLE
OPENJPA-2836 HerdDBDictionary: enable ForeignKeys and Unique Indexes

### DIFF
--- a/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/HerdDBDictionary.java
+++ b/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/HerdDBDictionary.java
@@ -33,6 +33,7 @@ public class HerdDBDictionary
         delimitedCase = SCHEMA_CASE_LOWER;
 
         supportsCascadeUpdateAction = false;
+        supportsDeferredConstraints = false;
 
         // make OpenJPA escape everything, because Apache Calcite has a lot of reserved words, like 'User', 'Value'...
         setDelimitIdentifiers(true);

--- a/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/HerdDBDictionary.java
+++ b/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/HerdDBDictionary.java
@@ -32,6 +32,8 @@ public class HerdDBDictionary
         schemaCase = SCHEMA_CASE_LOWER;
         delimitedCase = SCHEMA_CASE_LOWER;
 
+        supportsCascadeUpdateAction = false;
+
         // make OpenJPA escape everything, because Apache Calcite has a lot of reserved words, like 'User', 'Value'...
         setDelimitIdentifiers(true);
         setSupportsDelimitedIdentifiers(true);

--- a/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/HerdDBDictionary.java
+++ b/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/HerdDBDictionary.java
@@ -29,9 +29,6 @@ public class HerdDBDictionary
     public HerdDBDictionary() {
         platform = "HerdDB";
         databaseProductName = "HerdDB";
-        supportsForeignKeys = false;
-        supportsUniqueConstraints = false;
-        supportsCascadeDeleteAction = false;
         schemaCase = SCHEMA_CASE_LOWER;
         delimitedCase = SCHEMA_CASE_LOWER;
 

--- a/openjpa-jdbc/src/test/java/org/apache/openjpa/jdbc/sql/TestHerdDBDictionary.java
+++ b/openjpa-jdbc/src/test/java/org/apache/openjpa/jdbc/sql/TestHerdDBDictionary.java
@@ -147,11 +147,13 @@ public class TestHerdDBDictionary {
         fk1.join(n1, p1);
 
         String[] createTableSQL = dict.getCreateTableSQL(childTable);
-        assertEquals("CREATE TABLE `herddb`.`childTable` (`k1` VARCHAR NOT NULL, `n1` INTEGER, PRIMARY KEY (`k1`), CONSTRAINT `un1` UNIQUE (`n1`))", createTableSQL[0]);
+        assertEquals("CREATE TABLE `herddb`.`childTable` (`k1` VARCHAR NOT NULL, `n1` INTEGER, "
+                + "PRIMARY KEY (`k1`), CONSTRAINT `un1` UNIQUE (`n1`))", createTableSQL[0]);
         assertEquals(1, createTableSQL.length);
 
         String[] addForeignKeySQL = dict.getAddForeignKeySQL(fk1);
-        assertEquals("ALTER TABLE `herddb`.`childTable` ADD CONSTRAINT `fk1` FOREIGN KEY (`n1`) REFERENCES `herddb`.`parentTable` (`p1`) ON DELETE CASCADE", addForeignKeySQL[0]);
+        assertEquals("ALTER TABLE `herddb`.`childTable` ADD CONSTRAINT `fk1` "
+                + "FOREIGN KEY (`n1`) REFERENCES `herddb`.`parentTable` (`p1`) ON DELETE CASCADE", addForeignKeySQL[0]);
         assertEquals(1, addForeignKeySQL.length);
 
         String[] dropForeignKeySQL = dict.getDropForeignKeySQL(fk1, mockConnection);
@@ -172,7 +174,8 @@ public class TestHerdDBDictionary {
         // ON DELETE RESTRICT is the default behaviour, so no need to write it in DDL
         fk2.setUpdateAction(ForeignKey.ACTION_NULL);
         String[] addForeignKeySQL3 = dict.getAddForeignKeySQL(fk2);
-        assertEquals("ALTER TABLE `herddb`.`childTable` ADD CONSTRAINT `fk2` FOREIGN KEY (`n1`) REFERENCES `herddb`.`parentTable` (`p1`) ON UPDATE SET NULL", addForeignKeySQL3[0]);
+        assertEquals("ALTER TABLE `herddb`.`childTable` ADD CONSTRAINT `fk2` "
+                + "FOREIGN KEY (`n1`) REFERENCES `herddb`.`parentTable` (`p1`) ON UPDATE SET NULL", addForeignKeySQL3[0]);
         assertEquals(1, addForeignKeySQL3.length);
     }
 

--- a/openjpa-jdbc/src/test/java/org/apache/openjpa/jdbc/sql/TestHerdDBDictionary.java
+++ b/openjpa-jdbc/src/test/java/org/apache/openjpa/jdbc/sql/TestHerdDBDictionary.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.openjpa.jdbc.sql;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.apache.openjpa.jdbc.conf.JDBCConfiguration;
+import org.apache.openjpa.kernel.StoreContext;
+import org.jmock.Expectations;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TestHerdDBDictionary {
+    @Rule
+    public JUnitRuleMockery context = new JUnitRuleMockery();
+
+    final JDBCConfiguration mockConfiguration = context.mock(JDBCConfiguration.class);
+    final Statement mockStatement = context.mock(Statement.class);
+    final Connection mockConnection = context.mock(Connection.class);
+    final ResultSet mockRS = context.mock(ResultSet.class);
+    final DataSource mockDS = context.mock(DataSource.class);
+    final DatabaseMetaData mockMetaData = context.mock(DatabaseMetaData.class);
+
+    final StoreContext sc = null;
+
+    @Test
+    public void testBootDBDictionary() throws Exception {
+        // Expected method calls on the mock objects above. If any of these are
+        // do not occur, or if any other methods are invoked on the mock objects
+        // an exception will be thrown and the test will fail.
+        context.checking(new Expectations()
+        {
+            {
+                allowing(mockConfiguration);
+            }
+        });
+
+        DBDictionary dict = new HerdDBDictionary();
+        dict.setConfiguration(mockConfiguration);
+        assertNull(dict.getDefaultSchemaName());
+
+        assertTrue(dict.supportsForeignKeys);
+        assertTrue(dict.supportsUniqueConstraints);
+        assertTrue(dict.supportsCascadeDeleteAction);
+        assertFalse(dict.supportsCascadeUpdateAction);
+    }
+
+}

--- a/openjpa-jdbc/src/test/java/org/apache/openjpa/jdbc/sql/TestHerdDBDictionary.java
+++ b/openjpa-jdbc/src/test/java/org/apache/openjpa/jdbc/sql/TestHerdDBDictionary.java
@@ -18,6 +18,7 @@
  */
 package org.apache.openjpa.jdbc.sql;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -27,7 +28,17 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import javax.sql.DataSource;
 import org.apache.openjpa.jdbc.conf.JDBCConfiguration;
+import org.apache.openjpa.jdbc.conf.JDBCConfigurationImpl;
+import org.apache.openjpa.jdbc.identifier.DBIdentifier;
+import org.apache.openjpa.jdbc.identifier.DBIdentifierUtil;
+import org.apache.openjpa.jdbc.identifier.DBIdentifierUtilImpl;
+import org.apache.openjpa.jdbc.schema.Column;
+import org.apache.openjpa.jdbc.schema.ForeignKey;
+import org.apache.openjpa.jdbc.schema.Schema;
+import org.apache.openjpa.jdbc.schema.SchemaGroup;
+import org.apache.openjpa.jdbc.schema.Table;
 import org.apache.openjpa.kernel.StoreContext;
+import org.hsqldb.types.Types;
 import org.jmock.Expectations;
 import org.jmock.integration.junit4.JUnitRuleMockery;
 import org.junit.Rule;
@@ -37,7 +48,6 @@ public class TestHerdDBDictionary {
     @Rule
     public JUnitRuleMockery context = new JUnitRuleMockery();
 
-    final JDBCConfiguration mockConfiguration = context.mock(JDBCConfiguration.class);
     final Statement mockStatement = context.mock(Statement.class);
     final Connection mockConnection = context.mock(Connection.class);
     final ResultSet mockRS = context.mock(ResultSet.class);
@@ -54,18 +64,116 @@ public class TestHerdDBDictionary {
         context.checking(new Expectations()
         {
             {
-                allowing(mockConfiguration);
+
+                allowing(mockConnection).getMetaData();
+                will(returnValue(mockMetaData));
+
+                allowing(mockMetaData).getDatabaseProductName();
+                will(returnValue("MockDB"));
+
+                allowing(mockMetaData).getDriverName();
+                will(returnValue("MockDB"));
+
+                allowing(mockMetaData).getDriverVersion();
+                will(returnValue("1.0"));
+
+                allowing(mockMetaData).getDatabaseProductVersion();
+                will(returnValue("10"));
+
+                allowing(mockMetaData).getDatabaseMajorVersion();
+                will(returnValue(10));
+
+                allowing(mockMetaData).getDatabaseMinorVersion();
+                will(returnValue(0));
+
+                allowing(mockMetaData).getJDBCMajorVersion();
+                will(returnValue(4));
+
+                allowing(mockMetaData).getJDBCMinorVersion();
+                will(returnValue(0));
+
+                allowing(mockMetaData).supportsMixedCaseIdentifiers();
+                will(returnValue(true));
+
+                allowing(mockMetaData).supportsMixedCaseQuotedIdentifiers();
+                will(returnValue(true));
+
+                allowing(mockMetaData).storesLowerCaseQuotedIdentifiers();
+                will(returnValue(true));
+
+                allowing(mockMetaData).storesUpperCaseQuotedIdentifiers();
+                will(returnValue(false));
+
+                allowing(mockMetaData).storesMixedCaseQuotedIdentifiers();
+                will(returnValue(false));
+
+                allowing(mockMetaData).supportsGetGeneratedKeys();
+                will(returnValue(false));
+
             }
         });
+        JDBCConfiguration jdbcConfiguration = new JDBCConfigurationImpl(false);
 
         DBDictionary dict = new HerdDBDictionary();
-        dict.setConfiguration(mockConfiguration);
+        dict.setConfiguration(jdbcConfiguration);
         assertNull(dict.getDefaultSchemaName());
+        dict.connectedConfiguration(mockConnection);
 
         assertTrue(dict.supportsForeignKeys);
         assertTrue(dict.supportsUniqueConstraints);
         assertTrue(dict.supportsCascadeDeleteAction);
         assertFalse(dict.supportsCascadeUpdateAction);
+        assertFalse(dict.supportsDeferredConstraints);
+
+        SchemaGroup schemaGroup = new SchemaGroup();
+        Schema schema = new Schema(DBIdentifier.newSchema("herddb", true), schemaGroup);
+
+        Table parentTable = new Table(DBIdentifier.newTable("parentTable", true), schema);
+        Column p1 = parentTable.addColumn(DBIdentifier.newColumn("p1", true));
+        p1.setType(Types.VARCHAR);
+
+        Table childTable = new Table(DBIdentifier.newTable("childTable", true), schema);
+        childTable.setComment("This is a comment");
+        Column k1 = childTable.addColumn(DBIdentifier.newColumn("k1", true));
+        k1.setType(Types.VARCHAR);
+        Column n1 = childTable.addColumn(DBIdentifier.newColumn("n1", true));
+        n1.setType(Types.INTEGER);
+        childTable.addPrimaryKey().addColumn(k1);
+
+        childTable.addUnique(DBIdentifier.newConstraint("un1")).addColumn(n1);
+
+        ForeignKey fk1 = childTable.addForeignKey(DBIdentifier.newForeignKey("fk1", true));
+        fk1.setDeleteAction(ForeignKey.ACTION_CASCADE);
+        fk1.join(n1, p1);
+
+        String[] createTableSQL = dict.getCreateTableSQL(childTable);
+        assertEquals("CREATE TABLE `herddb`.`childTable` (`k1` VARCHAR NOT NULL, `n1` INTEGER, PRIMARY KEY (`k1`), CONSTRAINT `un1` UNIQUE (`n1`))", createTableSQL[0]);
+        assertEquals(1, createTableSQL.length);
+
+        String[] addForeignKeySQL = dict.getAddForeignKeySQL(fk1);
+        assertEquals("ALTER TABLE `herddb`.`childTable` ADD CONSTRAINT `fk1` FOREIGN KEY (`n1`) REFERENCES `herddb`.`parentTable` (`p1`) ON DELETE CASCADE", addForeignKeySQL[0]);
+        assertEquals(1, addForeignKeySQL.length);
+
+        String[] dropForeignKeySQL = dict.getDropForeignKeySQL(fk1, mockConnection);
+        assertEquals("ALTER TABLE `herddb`.`childTable` DROP CONSTRAINT `fk1`", dropForeignKeySQL[0]);
+        assertEquals(1, dropForeignKeySQL.length);
+
+
+        ForeignKey fk2 = childTable.addForeignKey(DBIdentifier.newForeignKey("fk2", true));
+        fk2.setDeleteAction(ForeignKey.ACTION_RESTRICT);
+        fk2.setUpdateAction(ForeignKey.ACTION_CASCADE); // not supported
+        fk2.join(n1, p1);
+
+        // ON UPDATE CASCADE is not supported, so we are not adding the constraint
+        String[] addForeignKeySQL2 = dict.getAddForeignKeySQL(fk2);
+        assertEquals(0, addForeignKeySQL2.length);
+
+        // ON UPDATE SET NULL is supported
+        // ON DELETE RESTRICT is the default behaviour, so no need to write it in DDL
+        fk2.setUpdateAction(ForeignKey.ACTION_NULL);
+        String[] addForeignKeySQL3 = dict.getAddForeignKeySQL(fk2);
+        assertEquals("ALTER TABLE `herddb`.`childTable` ADD CONSTRAINT `fk2` FOREIGN KEY (`n1`) REFERENCES `herddb`.`parentTable` (`p1`) ON UPDATE SET NULL", addForeignKeySQL3[0]);
+        assertEquals(1, addForeignKeySQL3.length);
     }
 
 }


### PR DESCRIPTION
Drop these lines from HerdDBDictionary, as HerdDB 0.21.0+ supports Unique Indexes and HerdDB 0.22.0+ supports ForeignKeys with "ON DELETE CASCADE" action.

```
        supportsForeignKeys = false;
        supportsUniqueConstraints = false;
        supportsCascadeDeleteAction = false;
```