### PR TITLE
OPENJPA-2837 HerdDBDictionary does not work with 'native' SchemaFactory (LazySchemaFactory) - set useSchemaName=false by default

### DIFF
--- a/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/HerdDBDictionary.java
+++ b/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/HerdDBDictionary.java
@@ -31,6 +31,10 @@ public class HerdDBDictionary
         databaseProductName = "HerdDB";
         schemaCase = SCHEMA_CASE_LOWER;
         delimitedCase = SCHEMA_CASE_LOWER;
+        // OPENJPA-2837 with useSchemaName + delimiters TableJDBCSeq has serious problems
+        // in HerdDB the schema is mapped to a TableSpace and not a "database", not a big deal to have it disabled by default
+        // users can enabled it explictly in the PersistenceUnit configuraiton
+        useSchemaName = false;
 
         supportsCascadeUpdateAction = false;
         supportsDeferredConstraints = false;

--- a/openjpa-jdbc/src/test/java/org/apache/openjpa/jdbc/sql/TestHerdDBDictionary.java
+++ b/openjpa-jdbc/src/test/java/org/apache/openjpa/jdbc/sql/TestHerdDBDictionary.java
@@ -124,6 +124,7 @@ public class TestHerdDBDictionary {
         assertTrue(dict.supportsCascadeDeleteAction);
         assertFalse(dict.supportsCascadeUpdateAction);
         assertFalse(dict.supportsDeferredConstraints);
+        assertFalse(dict.useSchemaName);
 
         SchemaGroup schemaGroup = new SchemaGroup();
         Schema schema = new Schema(DBIdentifier.newSchema("herddb", true), schemaGroup);
@@ -147,17 +148,17 @@ public class TestHerdDBDictionary {
         fk1.join(n1, p1);
 
         String[] createTableSQL = dict.getCreateTableSQL(childTable);
-        assertEquals("CREATE TABLE `herddb`.`childTable` (`k1` VARCHAR NOT NULL, `n1` INTEGER, "
+        assertEquals("CREATE TABLE `childTable` (`k1` VARCHAR NOT NULL, `n1` INTEGER, "
                 + "PRIMARY KEY (`k1`), CONSTRAINT `un1` UNIQUE (`n1`))", createTableSQL[0]);
         assertEquals(1, createTableSQL.length);
 
         String[] addForeignKeySQL = dict.getAddForeignKeySQL(fk1);
-        assertEquals("ALTER TABLE `herddb`.`childTable` ADD CONSTRAINT `fk1` "
-                + "FOREIGN KEY (`n1`) REFERENCES `herddb`.`parentTable` (`p1`) ON DELETE CASCADE", addForeignKeySQL[0]);
+        assertEquals("ALTER TABLE `childTable` ADD CONSTRAINT `fk1` "
+                + "FOREIGN KEY (`n1`) REFERENCES `parentTable` (`p1`) ON DELETE CASCADE", addForeignKeySQL[0]);
         assertEquals(1, addForeignKeySQL.length);
 
         String[] dropForeignKeySQL = dict.getDropForeignKeySQL(fk1, mockConnection);
-        assertEquals("ALTER TABLE `herddb`.`childTable` DROP CONSTRAINT `fk1`", dropForeignKeySQL[0]);
+        assertEquals("ALTER TABLE `childTable` DROP CONSTRAINT `fk1`", dropForeignKeySQL[0]);
         assertEquals(1, dropForeignKeySQL.length);
 
 
@@ -174,8 +175,8 @@ public class TestHerdDBDictionary {
         // ON DELETE RESTRICT is the default behaviour, so no need to write it in DDL
         fk2.setUpdateAction(ForeignKey.ACTION_NULL);
         String[] addForeignKeySQL3 = dict.getAddForeignKeySQL(fk2);
-        assertEquals("ALTER TABLE `herddb`.`childTable` ADD CONSTRAINT `fk2` "
-                + "FOREIGN KEY (`n1`) REFERENCES `herddb`.`parentTable` (`p1`) ON UPDATE SET NULL", addForeignKeySQL3[0]);
+        assertEquals("ALTER TABLE `childTable` ADD CONSTRAINT `fk2` "
+                + "FOREIGN KEY (`n1`) REFERENCES `parentTable` (`p1`) ON UPDATE SET NULL", addForeignKeySQL3[0]);
         assertEquals(1, addForeignKeySQL3.length);
     }
 


### PR DESCRIPTION
More context on https://issues.apache.org/jira/browse/OPENJPA-2837