### PR TITLE
[OPENJPA-2891] allow configuration of @Generated annotation.

### DIFF
--- a/openjpa-persistence/pom.xml
+++ b/openjpa-persistence/pom.xml
@@ -60,5 +60,10 @@
             <version>4.2.0</version>
             <scope>provided</scope>
         </dependency>
+        <!-- annotation javax.annotation.Generated -->
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/openjpa-persistence/src/main/java/org/apache/openjpa/persistence/meta/AnnotationProcessor6.java
+++ b/openjpa-persistence/src/main/java/org/apache/openjpa/persistence/meta/AnnotationProcessor6.java
@@ -317,21 +317,27 @@ public class AnnotationProcessor6 extends AbstractProcessor {
         SourceCode.Class cls = source.getTopLevelClass();
         cls.addAnnotation(StaticMetamodel.class.getName())
             .addArgument("value", originalClass + ".class", false);
-        if ("false".equals(this.addGeneratedOption)) {
-            return;
-        }
 
-        if ("force".equals(this.addGeneratedOption)) {
-            cls.addAnnotation(javax.annotation.Generated.class.getName())
-                    .addArgument("value", this.getClass().getName())
-                    .addArgument("date", this.generationDate.toString());
-        }
+        switch (this.addGeneratedOption) {
+            case "false":
+                return;
 
-        // only add the annotation if it is on the classpath for Java 6+.
-        if (generatedAnnotation != null && generatedSourceVersion >= 6) {
-            cls.addAnnotation(generatedAnnotation.getName())
-                    .addArgument("value", this.getClass().getName())
-                    .addArgument("date", this.generationDate.toString());
+            case "force":
+                cls.addAnnotation(javax.annotation.Generated.class.getName())
+                        .addArgument("value", this.getClass().getName())
+                        .addArgument("date", this.generationDate.toString());
+                break;
+
+            case "auto":
+                // fall through
+            default:
+                // only add the annotation if it is on the classpath for Java 6+.
+                if (generatedAnnotation != null && generatedSourceVersion >= 6) {
+                    cls.addAnnotation(generatedAnnotation.getName())
+                            .addArgument("value", this.getClass().getName())
+                            .addArgument("date", this.generationDate.toString());
+                }
+                break;
         }
     }
 
@@ -398,6 +404,11 @@ public class AnnotationProcessor6 extends AbstractProcessor {
 
     private void setAddGeneratedAnnotation() {
         this.addGeneratedOption = getOptionValue("openjpa.addGeneratedAnnotation");
+
+        if (this.addGeneratedOption == null) {
+            this.addGeneratedOption = "auto";
+        }
+
         // only add the annotation if it is on the classpath for Java 6+.
         try {
             this.generatedAnnotation = Class.forName("javax.annotation.Generated", false, null);

--- a/openjpa-persistence/src/main/resources/org/apache/openjpa/persistence/meta/localizer.properties
+++ b/openjpa-persistence/src/main/resources/org/apache/openjpa/persistence/meta/localizer.properties
@@ -36,6 +36,8 @@ field-key-type-mismatch: Actual key type of map field "{0}" "{1}" does not \
 field-unrecognized: Field "{0}" is not recognized by its type code "{1}" to \
     be included in the meta model.
 getter-unmatched: Getter method "{0}" in "{1}" has no matching setter method.
+mmg-annotation-not-found: Annotation javax.annotation.Generated not found in \
+    the classpath. It will not be added to generated static metamodels.
 mmg-tool-banner: Starting OpenJPA Annotation Processor for Metamodel Generation
 mmg-process: Generating canonical metamodel source code "{0}"
 mmg-process-error: Error while generating metamodel for "{0}". See exception \

--- a/openjpa-project/src/doc/manual/jpa_overview_criteria.xml
+++ b/openjpa-project/src/doc/manual/jpa_overview_criteria.xml
@@ -202,6 +202,16 @@ the name of a meta-class given the name of the original persistent Java entity c
                By default, adds an OpenJPA proprietary text as comment block.
              </para>
         </listitem>
+        <listitem>
+            <para>
+                -Aopenjpa.addGeneratedAnnotation=auto|force|false : Configure whether the annotation
+                <code>javax.annotation.Generated</code> should be added to the generated metamodel classes.
+                This annotation is not available on Java 9 upwards unless the <code>javax.annotation-api</code>
+                is in the classpath.
+                The default is <code>auto</code>. Set to <code>force</code> to add the annotation even if it is
+                not in the classpath or to <code>false</code> to never add it to the generated class.
+            </para>
+        </listitem>
     </itemizedlist>
        </para>
     </section>

--- a/pom.xml
+++ b/pom.xml
@@ -1794,6 +1794,12 @@
                 <version>2.2.1</version>
             </dependency>
             <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-impl</artifactId>
                 <version>2.2.1</version>


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/OPENJPA-2891

Question: The annotation dependency is only necessary if compiled with Java9+, but this project cannot be compiled with Java9+ at the moment. I can remove it if you would like me to.

This implementation uses a String, because this makes the parameters more extensible. You can add other parameters later. `forced` is used instead of `true` because it will be added in every situation. `true` and `null` are interchangable in this implementation.

Documentation needs to be updated as well.

Also, this is my first OpenJPA commit. Please review the code style.

Logic: 
* If nothing is set, try to see if the annotation is on the classpath and we are on Java6+.
* If `-Aopenjpa.addGeneratedAnnotation=false` is set, the annotation is never added.
* If `-Aopenjpa.addGeneratedAnnotation=force` is set, the annotation is always added (regardless of classpath availability and/or Java version).