### PR TITLE
Log4j2 update to last version (free of vulnerability such as Log4Shell)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 
         <xbean.version>4.20</xbean.version>
         <bval.version>1.1.2</bval.version>
-        <log4j2.version>2.14.1</log4j2.version>
+        <log4j2.version>2.18.0</log4j2.version>
         <ant.version>1.10.9</ant.version>
 
         <jmock.version>2.9.0</jmock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 
         <xbean.version>4.20</xbean.version>
         <bval.version>1.1.2</bval.version>
-        <log4j2.version>2.18.0</log4j2.version>
+        <log4j2.version>2.19.0</log4j2.version>
         <ant.version>1.10.9</ant.version>
 
         <jmock.version>2.9.0</jmock.version>


### PR DESCRIPTION
Hi,
The fact is that old version of Log4j2 are sometimes filtered by proxies resulting in a build failed due to missing dependency (that alos impact other project depending on this one, such as Camel).
And in a more global reflection, I think it is better to have a "clean" log4j2 version ;)
