### PR TITLE
[OPENJPA-2936] Fixes unnamed index synchronization

### DIFF
--- a/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/meta/MappingInfo.java
+++ b/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/meta/MappingInfo.java
@@ -21,8 +21,10 @@ package org.apache.openjpa.jdbc.meta;
 import java.io.Serializable;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.openjpa.jdbc.conf.JDBCConfiguration;
 import org.apache.openjpa.jdbc.identifier.DBIdentifier;
@@ -948,10 +950,11 @@ public abstract class MappingInfo implements Serializable {
 
         // if no name provided by user info, make one
         if (DBIdentifier.isNull(name)) {
-            if (tmplate != null)
+            if (tmplate != null && !DBIdentifier.isNull(tmplate.getIdentifier()))
                 name = tmplate.getIdentifier();
             else {
-                name = cols[0].getIdentifier();
+            	name = DBIdentifier.newIndex(Arrays.stream(cols)
+            			.map(c -> c.getIdentifier().getName()).collect(Collectors.joining("_")));
                 name = repos.getDBDictionary().getValidIndexName(name, table);
             }
         }

--- a/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/meta/MappingInfo.java
+++ b/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/meta/MappingInfo.java
@@ -950,11 +950,11 @@ public abstract class MappingInfo implements Serializable {
 
         // if no name provided by user info, make one
         if (DBIdentifier.isNull(name)) {
-            if (tmplate != null && !DBIdentifier.isNull(tmplate.getIdentifier()))
+            if (tmplate != null && !DBIdentifier.isNull(tmplate.getIdentifier())) {
                 name = tmplate.getIdentifier();
-            else {
-            	name = DBIdentifier.newIndex(Arrays.stream(cols)
-            			.map(c -> c.getIdentifier().getName()).collect(Collectors.joining("_")));
+            } else {
+                name = DBIdentifier.newIndex(Arrays.stream(cols)
+                        .map(c -> c.getIdentifier().getName()).collect(Collectors.joining("_")));
                 name = repos.getDBDictionary().getValidIndexName(name, table);
             }
         }

--- a/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/jdbc/annotations/EntityWithIndices.java
+++ b/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/jdbc/annotations/EntityWithIndices.java
@@ -29,7 +29,8 @@ import jakarta.persistence.Table;
     , indexes = {@Index(name = "idx_index1", columnList = "INDEX1")
         , @Index(name = "idx_long", columnList = "LONG_NAME", unique = true)
         , @Index(name = "idx_wo_spaces", columnList = "INDEX1,COL2,COL3")
-        , @Index(name = "idx_with_spaces", columnList = " LONG_NAME , COL2, COL3 ")})
+        , @Index(name = "idx_with_spaces", columnList = " LONG_NAME , COL2, COL3 ")
+        , @Index(columnList = "LONG_NAME, COL2")})
 public class EntityWithIndices {
     @Id
     @Column(name = "PK")

--- a/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/jdbc/annotations/TestIndices.java
+++ b/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/jdbc/annotations/TestIndices.java
@@ -66,10 +66,8 @@ public class TestIndices extends SingleEMFTestCase {
 
         // test multi column index without spaces
         assertIndexColumns(table, "idx_wo_spaces", "INDEX1", "COL2", "COL3");
-
         // test multi column index without spaces
         assertIndexColumns(table, "idx_with_spaces", "LONG_NAME", "COL2", "COL3");
-        
         // test indexes without defined name
         assertHasIndexWithColumns(table, "LONG_NAME", "COL2");
     }
@@ -77,32 +75,31 @@ public class TestIndices extends SingleEMFTestCase {
     private void assertIndexColumns(Table table, String indexName, String... assertedColumnNames) {
         Index idx = table.getIndex(DBIdentifier.newIndex(indexName));
         assertNotNull("Defined index should exist", idx);
-        
         final List<String> indexColumnNames = Arrays.stream(idx.getColumns())
                 .map(c -> c.getIdentifier().getName())
                 .collect(Collectors.toList());
-
         for (String assertedColumnName : assertedColumnNames) {
             assertTrue("Column " + assertedColumnName + " does not exist in index " + indexName, indexColumnNames.contains(assertedColumnName));
         }
     }
 
     private void assertHasIndexWithColumns(Table table, String...assertedColumnNames) {
-    	for (Index idx: table.getIndexes()) {
-    		Column[] cols = idx.getColumns();
-    		if (cols.length != assertedColumnNames.length)
-    			continue;
-    		else {
-    			String[] colNames = Arrays.stream(cols)
-    				.map(Column::getIdentifier)
-    				.map(DBIdentifier::getName)
-    				.collect(Collectors.toList())
-    				.toArray(String[]::new);
-    			if (Arrays.equals(colNames, assertedColumnNames))
-    				return;
-    		}
-    	}
-    	fail("Could not find an unnamed index with the given columns.");
+        for (Index idx: table.getIndexes()) {
+            Column[] cols = idx.getColumns();
+            if (cols.length != assertedColumnNames.length) {
+                continue;
+            } else {
+                String[] colNames = Arrays.stream(cols)
+                    .map(Column::getIdentifier)
+                    .map(DBIdentifier::getName)
+                    .collect(Collectors.toList())
+                    .toArray(String[]::new);
+                if (Arrays.equals(colNames, assertedColumnNames)) {
+                    return;
+                }
+            }
+        }
+        fail("Could not find an unnamed index with the given columns.");
     }
     
 }

--- a/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/jdbc/annotations/TestIndices.java
+++ b/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/jdbc/annotations/TestIndices.java
@@ -69,12 +69,15 @@ public class TestIndices extends SingleEMFTestCase {
 
         // test multi column index without spaces
         assertIndexColumns(table, "idx_with_spaces", "LONG_NAME", "COL2", "COL3");
+        
+        // test indexes without defined name
+        assertHasIndexWithColumns(table, "LONG_NAME", "COL2");
     }
 
     private void assertIndexColumns(Table table, String indexName, String... assertedColumnNames) {
         Index idx = table.getIndex(DBIdentifier.newIndex(indexName));
         assertNotNull("Defined index should exist", idx);
-
+        
         final List<String> indexColumnNames = Arrays.stream(idx.getColumns())
                 .map(c -> c.getIdentifier().getName())
                 .collect(Collectors.toList());
@@ -83,4 +86,23 @@ public class TestIndices extends SingleEMFTestCase {
             assertTrue("Column " + assertedColumnName + " does not exist in index " + indexName, indexColumnNames.contains(assertedColumnName));
         }
     }
+
+    private void assertHasIndexWithColumns(Table table, String...assertedColumnNames) {
+    	for (Index idx: table.getIndexes()) {
+    		Column[] cols = idx.getColumns();
+    		if (cols.length != assertedColumnNames.length)
+    			continue;
+    		else {
+    			String[] colNames = Arrays.stream(cols)
+    				.map(Column::getIdentifier)
+    				.map(DBIdentifier::getName)
+    				.collect(Collectors.toList())
+    				.toArray(String[]::new);
+    			if (Arrays.equals(colNames, assertedColumnNames))
+    				return;
+    		}
+    	}
+    	fail("Could not find an unnamed index with the given columns.");
+    }
+    
 }


### PR DESCRIPTION
* Allow creation of indexes using columns names
* Modified TestIndices to test creation of unnamed index

Tested on default db, h2, h2-2, postgresql.