### PR TITLE
[OPENJPA-3002] Fix: @Index(columnNames) at field level is now correctly applied

### DIFF
--- a/openjpa-persistence-jdbc/src/main/java/org/apache/openjpa/persistence/jdbc/AnnotationPersistenceMappingParser.java
+++ b/openjpa-persistence-jdbc/src/main/java/org/apache/openjpa/persistence/jdbc/AnnotationPersistenceMappingParser.java
@@ -1063,7 +1063,7 @@ public class AnnotationPersistenceMappingParser
      * Parse the given index.
      */
     private void parseIndex(MappingInfo info, Index idx) {
-    parseIndex(info, idx.name(), idx.enabled(), idx.unique(), idx.columnNames());
+        parseIndex(info, idx.name(), idx.enabled(), idx.unique(), idx.columnNames());
     }
 
     /**
@@ -1090,11 +1090,12 @@ public class AnnotationPersistenceMappingParser
             idx.setIdentifier(DBIdentifier.newConstraint(name, delimit()));
         idx.setUnique(unique);
 
-        if (columnNames != null) for (String columnName : columnNames) {
-            org.apache.openjpa.jdbc.schema.Column column =
-                    new org.apache.openjpa.jdbc.schema.Column();
-            column.setIdentifier(DBIdentifier.newColumn(columnName, delimit()));
-            idx.addColumn(column);
+        if (columnNames != null) {
+            for (String columnName : columnNames) {
+                Column column = new Column();
+                column.setIdentifier(DBIdentifier.newColumn(columnName, delimit()));
+                idx.addColumn(column);
+            }
         }
 
         info.setIndex(idx);

--- a/openjpa-persistence-jdbc/src/main/java/org/apache/openjpa/persistence/jdbc/AnnotationPersistenceMappingParser.java
+++ b/openjpa-persistence-jdbc/src/main/java/org/apache/openjpa/persistence/jdbc/AnnotationPersistenceMappingParser.java
@@ -193,16 +193,16 @@ import jakarta.persistence.UniqueConstraint;
  * @author Abe White
  */
 public class AnnotationPersistenceMappingParser
-        extends AnnotationPersistenceMetaDataParser {
+    extends AnnotationPersistenceMetaDataParser {
 
     protected static final int TRUE = 1;
     protected static final int FALSE = 2;
 
     private static final Localizer _loc = Localizer.forPackage
-            (AnnotationPersistenceMappingParser.class);
+        (AnnotationPersistenceMappingParser.class);
 
     private static final Map<Class<?>, MappingTag> _tags =
-            new HashMap<>();
+        new HashMap<>();
 
     private final DBDictionary _dict;
 
@@ -314,7 +314,7 @@ public class AnnotationPersistenceMappingParser
                     break;
                 default:
                     throw new UnsupportedException(_loc.get("unsupported", pkg,
-                            anno.toString()));
+                        anno.toString()));
             }
         }
     }
@@ -323,7 +323,7 @@ public class AnnotationPersistenceMappingParser
      * Allow subclasses to handle unknown annotations.
      */
     protected boolean handleUnknownPackageMappingAnnotation(Package pkg,
-            Annotation anno) {
+        Annotation anno) {
         return false;
     }
 
@@ -340,7 +340,7 @@ public class AnnotationPersistenceMappingParser
             log.trace(_loc.get("parse-gen", name));
 
         SequenceMapping meta = (SequenceMapping) getRepository().
-                getCachedSequenceMetaData(name);
+            getCachedSequenceMetaData(name);
         if (meta != null) {
             if (log.isWarnEnabled())
                 log.warn(_loc.get("dup-gen", name, el));
@@ -356,19 +356,19 @@ public class AnnotationPersistenceMappingParser
         meta.setInitialValue(gen.initialValue());
         meta.setAllocate(gen.allocationSize());
         meta.setSource(getSourceFile(), (el instanceof Class) ? el : null,
-                SourceTracker.SRC_ANNOTATIONS);
+            SourceTracker.SRC_ANNOTATIONS);
 
         switch (gen.uniqueConstraints().length) {
-            case 0:
-                break; // nothing to do
-            case 1:
-                meta.setUniqueColumnsIdentifier(DBIdentifier.toArray(gen.uniqueConstraints()[0].columnNames(),
-                        DBIdentifierType.COLUMN, delimit()));
-                meta.setUniqueConstraintIdentifier(DBIdentifier.newConstraint(gen.uniqueConstraints()[0].name(),
-                        delimit()));
-                break;
-            default:
-                log.warn(_loc.get("unique-many-on-seq-unsupported", el, name));
+        case 0:
+        	break; // nothing to do
+        case 1:
+        	meta.setUniqueColumnsIdentifier(DBIdentifier.toArray(gen.uniqueConstraints()[0].columnNames(),
+        	    DBIdentifierType.COLUMN, delimit()));
+        	meta.setUniqueConstraintIdentifier(DBIdentifier.newConstraint(gen.uniqueConstraints()[0].name(),
+        	    delimit()));
+        	break;
+        default:
+        	log.warn(_loc.get("unique-many-on-seq-unsupported", el, name));
         }
     }
 
@@ -391,26 +391,26 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case ASSOC_OVERRIDES:
                     parseAssociationOverrides(cm, ((AssociationOverrides) anno).
-                            value());
+                        value());
                     break;
                 case ATTR_OVERRIDE:
                     parseAttributeOverrides(cm, (AttributeOverride) anno);
                     break;
                 case ATTR_OVERRIDES:
                     parseAttributeOverrides(cm, ((AttributeOverrides) anno).
-                            value());
+                        value());
                     break;
                 case DISCRIM_COL:
                     parseDiscriminatorColumn(cm, (DiscriminatorColumn) anno);
                     break;
                 case DISCRIM_VAL:
                     cm.getDiscriminator().getMappingInfo().setValue
-                            (((DiscriminatorValue) anno).value());
+                        (((DiscriminatorValue) anno).value());
                     if (Modifier.isAbstract(cm.getDescribedType().
                             getModifiers()) && getLog().isInfoEnabled()) {
                         getLog().info(
-                                _loc.get("discriminator-on-abstract-class", cm
-                                        .getDescribedType().getName()));
+                            _loc.get("discriminator-on-abstract-class", cm
+                                    .getDescribedType().getName()));
                     }
                     break;
                 case INHERITANCE:
@@ -421,8 +421,8 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case PK_JOIN_COLS:
                     parsePrimaryKeyJoinColumns(cm,
-                            ((PrimaryKeyJoinColumns) anno).
-                                    value());
+                        ((PrimaryKeyJoinColumns) anno).
+                            value());
                     break;
                 case SECONDARY_TABLE:
                     parseSecondaryTables(cm, (SecondaryTable) anno);
@@ -435,7 +435,7 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case SQL_RESULT_SET_MAPPINGS:
                     parseSQLResultSetMappings(cm, ((SqlResultSetMappings) anno).
-                            value());
+                        value());
                     break;
                 case TABLE:
                     parseTable(cm, (Table) anno);
@@ -453,7 +453,7 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case DISCRIM_STRAT:
                     cm.getDiscriminator().getMappingInfo().setStrategy
-                            (((DiscriminatorStrategy) anno).value());
+                        (((DiscriminatorStrategy) anno).value());
                     break;
                 case FK:
                     parseForeignKey(cm.getMappingInfo(), (ForeignKey) anno);
@@ -463,14 +463,14 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case MAPPING_OVERRIDES:
                     parseMappingOverrides(cm,
-                            ((MappingOverrides) anno).value());
+                        ((MappingOverrides) anno).value());
                     break;
                 case STRAT:
                     cm.getMappingInfo().setStrategy(((Strategy) anno).value());
                     break;
                 case SUBCLASS_FETCH_MODE:
                     cm.setSubclassFetchMode(toEagerFetchModeConstant
-                            (((SubclassFetchMode) anno).value()));
+                        (((SubclassFetchMode) anno).value()));
                     break;
                 case VERSION_COL:
                     parseVersionColumns(cm, (VersionColumn) anno);
@@ -480,14 +480,14 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case VERSION_STRAT:
                     cm.getVersion().getMappingInfo().setStrategy
-                            (((VersionStrategy) anno).value());
+                        (((VersionStrategy) anno).value());
                     break;
                 case X_MAPPING_OVERRIDE:
                     parseMappingOverrides(cm, (XMappingOverride) anno);
                     break;
                 case X_MAPPING_OVERRIDES:
                     parseMappingOverrides(cm,
-                            ((XMappingOverrides) anno).value());
+                        ((XMappingOverrides) anno).value());
                     break;
                 case X_TABLE:
                 case X_SECONDARY_TABLE:
@@ -495,7 +495,7 @@ public class AnnotationPersistenceMappingParser
                     // no break; not supported yet
                 default:
                     throw new UnsupportedException(_loc.get("unsupported", cm,
-                            anno));
+                        anno));
             }
         }
     }
@@ -504,7 +504,7 @@ public class AnnotationPersistenceMappingParser
      * Allow subclasses to handle unknown annotations.
      */
     protected boolean handleUnknownClassMappingAnnotation(ClassMapping cls,
-            Annotation anno) {
+        Annotation anno) {
         return false;
     }
 
@@ -512,7 +512,7 @@ public class AnnotationPersistenceMappingParser
      * Parse @AssociationOverride(s).
      */
     private void parseAssociationOverrides(ClassMapping cm,
-            AssociationOverride... assocs) {
+        AssociationOverride... assocs) {
         FieldMapping sup;
         JoinColumn[] scols;
         int unique;
@@ -524,7 +524,7 @@ public class AnnotationPersistenceMappingParser
             sup = (FieldMapping) cm.getDefinedSuperclassField(assoc.name());
             if (sup == null)
                 sup = (FieldMapping) cm.addDefinedSuperclassField
-                        (assoc.name(), Object.class, Object.class);
+                    (assoc.name(), Object.class, Object.class);
             scols = assoc.joinColumns();
             joinTbl = assoc.joinTable();
             if ((scols == null || scols.length == 0) && joinTbl == null)
@@ -550,7 +550,7 @@ public class AnnotationPersistenceMappingParser
      * Parse @AttributeOverride(s).
      */
     private void parseAttributeOverrides(ClassMapping cm,
-            AttributeOverride... attrs) {
+        AttributeOverride... attrs) {
         FieldMapping sup;
         for (AttributeOverride attr : attrs) {
             if (StringUtil.isEmpty(attr.name()))
@@ -569,7 +569,7 @@ public class AnnotationPersistenceMappingParser
             sup = (FieldMapping) cm.getDefinedSuperclassField(attr.name());
             if (sup == null)
                 sup = (FieldMapping) cm.addDefinedSuperclassField(attr.name(),
-                        Object.class, Object.class);
+                    Object.class, Object.class);
             if (attr.column() != null)
                 parseColumns(sup, attr.column());
         }
@@ -579,7 +579,7 @@ public class AnnotationPersistenceMappingParser
      * Parse inheritance @PrimaryKeyJoinColumn(s).
      */
     private void parsePrimaryKeyJoinColumns(ClassMapping cm,
-            PrimaryKeyJoinColumn... joins) {
+        PrimaryKeyJoinColumn... joins) {
         List<Column> cols = new ArrayList<>(joins.length);
         for (PrimaryKeyJoinColumn join : joins)
             cols.add(newColumn(join));
@@ -605,7 +605,7 @@ public class AnnotationPersistenceMappingParser
      * Parse @SecondaryTable(s).
      */
     private void parseSecondaryTables(ClassMapping cm,
-            SecondaryTable... tables) {
+        SecondaryTable... tables) {
         ClassMappingInfo info = cm.getMappingInfo();
 
         List<Column> joins = null;
@@ -623,7 +623,7 @@ public class AnnotationPersistenceMappingParser
                     joins.add(newColumn(join));
                 info.setSecondaryTableJoinColumns(sName, joins);
             } else {
-                info.addSecondaryTable(sName);
+            	info.addSecondaryTable(sName);
             }
             // Parse @ForeignKey on @SecondaryTable
             jakarta.persistence.ForeignKey jpaFk = table.foreignKey();
@@ -653,7 +653,7 @@ public class AnnotationPersistenceMappingParser
         if (!StringUtil.isEmpty(table.options()))
             cm.getMappingInfo().setTableOptions(table.options());
         addUniqueConstraints(tName.getName(), cm, cm.getMappingInfo(),
-                table.uniqueConstraints());
+            table.uniqueConstraints());
         addIndices(tName.getName(), cm, cm.getMappingInfo(), table.indexes());
     }
 
@@ -678,7 +678,7 @@ public class AnnotationPersistenceMappingParser
     }
 
     void addUniqueConstraints(String table, MetaDataContext ctx,
-            MappingInfo info, UniqueConstraint... uniqueConstraints) {
+        MappingInfo info, UniqueConstraint... uniqueConstraints) {
         for (UniqueConstraint anno : uniqueConstraints) {
             Unique unique = createUniqueConstraint(ctx, anno);
             unique.setTableIdentifier(DBIdentifier.newTable(table, delimit()));
@@ -733,7 +733,7 @@ public class AnnotationPersistenceMappingParser
     }
 
     void addIndices(String table, MetaDataContext ctx,
-            MappingInfo info, jakarta.persistence.Index... indices) {
+        MappingInfo info, jakarta.persistence.Index... indices) {
         for (jakarta.persistence.Index anno : indices) {
             org.apache.openjpa.jdbc.schema.Index idx = createIndex(ctx, anno);
             idx.setTableIdentifier(DBIdentifier.newTable(table, delimit()));
@@ -764,7 +764,7 @@ public class AnnotationPersistenceMappingParser
      * {@link SQLResultSetMappingMetaData}.
      */
     private void parseSQLResultSetMappings(ClassMapping cm,
-            SqlResultSetMapping... annos) {
+        SqlResultSetMapping... annos) {
         MappingRepository repos = (MappingRepository) getRepository();
         Log log = getLog();
         for (SqlResultSetMapping anno : annos) {
@@ -772,7 +772,7 @@ public class AnnotationPersistenceMappingParser
                 log.trace(_loc.get("parse-sqlrsmapping", anno.name()));
 
             QueryResultMapping result = repos.getCachedQueryResultMapping
-                    (null, anno.name());
+                (null, anno.name());
             if (result != null) {
                 if (log.isWarnEnabled())
                     log.warn(_loc.get("dup-sqlrsmapping", anno.name(), cm));
@@ -781,14 +781,14 @@ public class AnnotationPersistenceMappingParser
 
             result = repos.addQueryResultMapping(null, anno.name());
             result.setSource(getSourceFile(), cm.getDescribedType(),
-                    SourceTracker.SRC_ANNOTATIONS);
+                SourceTracker.SRC_ANNOTATIONS);
 
             for (EntityResult entity : anno.entities()) {
                 QueryResultMapping.PCResult entityResult = result.addPCResult
-                        (entity.entityClass());
+                    (entity.entityClass());
                 if (!StringUtil.isEmpty(entity.discriminatorColumn()))
                     entityResult.addMapping(PCResult.DISCRIMINATOR,
-                            entity.discriminatorColumn());
+                        entity.discriminatorColumn());
 
                 for (FieldResult field : entity.fields()) {
                     DBIdentifier sColName = DBIdentifier.newColumn(field.column(), delimit());
@@ -874,7 +874,7 @@ public class AnnotationPersistenceMappingParser
      * Parse @DiscriminatorColumn.
      */
     private void parseDiscriminatorColumn(ClassMapping cm,
-            DiscriminatorColumn dcol) {
+        DiscriminatorColumn dcol) {
         Column col = new Column();
         if (!StringUtil.isEmpty(dcol.name())) {
             col.setIdentifier(DBIdentifier.newColumn(dcol.name(),delimit()));
@@ -927,7 +927,7 @@ public class AnnotationPersistenceMappingParser
      * Parse class-level @MappingOverride(s).
      */
     private void parseMappingOverrides(ClassMapping cm,
-            MappingOverride... overs) {
+        MappingOverride... overs) {
         FieldMapping sup;
         for (MappingOverride over : overs) {
             if (StringUtil.isEmpty(over.name()))
@@ -935,7 +935,7 @@ public class AnnotationPersistenceMappingParser
             sup = (FieldMapping) cm.getDefinedSuperclassField(over.name());
             if (sup == null)
                 sup = (FieldMapping) cm.addDefinedSuperclassField(over.name(),
-                        Object.class, Object.class);
+                    Object.class, Object.class);
             populate(sup, over);
         }
     }
@@ -972,28 +972,28 @@ public class AnnotationPersistenceMappingParser
      * Parse the given foreign key.
      */
     private void parseForeignKey(MappingInfo info, ForeignKey fk) {
-        if (!fk.implicit()) {
-            parseForeignKey(info, fk.name(), fk.enabled(), fk.deferred(),
-                    fk.deleteAction(), fk.updateAction());
-        } else {
+    	if (!fk.implicit()) {
+    		parseForeignKey(info, fk.name(), fk.enabled(), fk.deferred(),
+    				fk.deleteAction(), fk.updateAction());
+    	} else {
             info.setImplicitRelation(true);
             assertDefault(fk);
-        }
+    	}
     }
 
     /**
      * Set foreign key data on the given mapping info.
      */
     protected void parseForeignKey(MappingInfo info, String name,
-            boolean enabled, boolean deferred, ForeignKeyAction deleteAction,
-            ForeignKeyAction updateAction) {
+        boolean enabled, boolean deferred, ForeignKeyAction deleteAction,
+        ForeignKeyAction updateAction) {
         if (!enabled) {
             info.setCanForeignKey(false);
             return;
         }
 
         org.apache.openjpa.jdbc.schema.ForeignKey fk =
-                new org.apache.openjpa.jdbc.schema.ForeignKey();
+            new org.apache.openjpa.jdbc.schema.ForeignKey();
         if (!StringUtil.isEmpty(name))
             fk.setIdentifier(DBIdentifier.newForeignKey(name, delimit()));
         fk.setDeferred(deferred);
@@ -1028,15 +1028,15 @@ public class AnnotationPersistenceMappingParser
 
     void assertDefault(ForeignKey fk) {
         boolean isDefault = StringUtil.isEmpty(fk.name())
-                && fk.enabled()
-                && !fk.deferred()
+            && fk.enabled()
+            && !fk.deferred()
                 && fk.deleteAction() == ForeignKeyAction.RESTRICT
                 && fk.updateAction() == ForeignKeyAction.RESTRICT
-                && fk.columnNames().length == 0
-                && fk.specified();
+            && fk.columnNames().length == 0
+            && fk.specified();
         if (!isDefault)
             throw new UserException(_loc.get("implicit-non-default-fk", _cls,
-                    getSourceFile()).getMessage());
+                getSourceFile()).getMessage());
     }
 
 
@@ -1070,7 +1070,7 @@ public class AnnotationPersistenceMappingParser
      * Set index data on the given mapping info.
      */
     protected void parseIndex(MappingInfo info, String name,
-            boolean enabled, boolean unique) {
+        boolean enabled, boolean unique) {
         parseIndex(info, name, enabled, unique, null);
     }
 
@@ -1078,14 +1078,14 @@ public class AnnotationPersistenceMappingParser
      * Set index data on the given mapping info, including optional explicit column names.
      */
     protected void parseIndex(MappingInfo info, String name,
-            boolean enabled, boolean unique, String[] columnNames) {
+        boolean enabled, boolean unique, String[] columnNames) {
         if (!enabled) {
             info.setCanIndex(false);
             return;
         }
 
         org.apache.openjpa.jdbc.schema.Index idx =
-                new org.apache.openjpa.jdbc.schema.Index();
+            new org.apache.openjpa.jdbc.schema.Index();
         if (!StringUtil.isEmpty(name))
             idx.setIdentifier(DBIdentifier.newConstraint(name, delimit()));
         idx.setUnique(unique);
@@ -1105,7 +1105,7 @@ public class AnnotationPersistenceMappingParser
      * Set unique data on the given mapping info.
      */
     private void parseUnique(FieldMapping fm,
-            org.apache.openjpa.persistence.jdbc.Unique anno) {
+        org.apache.openjpa.persistence.jdbc.Unique anno) {
         ValueMappingInfo info = fm.getValueInfo();
         if (!anno.enabled()) {
             info.setCanUnique(false);
@@ -1113,7 +1113,7 @@ public class AnnotationPersistenceMappingParser
         }
 
         org.apache.openjpa.jdbc.schema.Unique unq =
-                new org.apache.openjpa.jdbc.schema.Unique();
+            new org.apache.openjpa.jdbc.schema.Unique();
         if (!StringUtil.isEmpty(anno.name()))
             unq.setIdentifier(DBIdentifier.newIndex(anno.name(), delimit()));
         unq.setDeferred(anno.deferred());
@@ -1138,15 +1138,15 @@ public class AnnotationPersistenceMappingParser
      */
     private static Column newColumn(VersionColumn anno, boolean delimit) {
         return newColumn(anno.name(),
-                anno.nullable(),
-                anno.insertable(),
-                anno.updatable(),
-                anno.columnDefinition(),
-                anno.length(),
-                anno.precision(),
-                anno.scale(),
-                anno.table(),
-                delimit);
+            anno.nullable(),
+            anno.insertable(),
+            anno.updatable(),
+            anno.columnDefinition(),
+            anno.length(),
+            anno.precision(),
+            anno.scale(),
+            anno.table(),
+            delimit);
     }
 
     static Column newColumn(String name,
@@ -1173,7 +1173,7 @@ public class AnnotationPersistenceMappingParser
             col.setTypeIdentifier(DBIdentifier.newColumnDefinition(columnDefinition));
             col.setType(Schemas.getJDBCType(col.getTypeIdentifier().getName()));
             col.setJavaType(JavaTypes.getTypeCode(Schemas.getJavaType
-                    (col.getType(), col.getSize(), col.getDecimalDigits())));
+                (col.getType(), col.getSize(), col.getDecimalDigits())));
         }
         col.setFlag(Column.FLAG_UNINSERTABLE, !insertable);
         col.setFlag(Column.FLAG_UNUPDATABLE, !updatable);
@@ -1185,7 +1185,7 @@ public class AnnotationPersistenceMappingParser
      * Parse class-level @XMappingOverride(s).
      */
     private void parseMappingOverrides(ClassMapping cm,
-            XMappingOverride... overs) {
+        XMappingOverride... overs) {
         FieldMapping sup;
         for (XMappingOverride over : overs) {
             if (StringUtil.isEmpty(over.name()))
@@ -1193,7 +1193,7 @@ public class AnnotationPersistenceMappingParser
             sup = (FieldMapping) cm.getDefinedSuperclassField(over.name());
             if (sup == null)
                 sup = (FieldMapping) cm.addDefinedSuperclassField(over.name(),
-                        Object.class, Object.class);
+                    Object.class, Object.class);
             populate(sup, over);
         }
     }
@@ -1303,9 +1303,9 @@ public class AnnotationPersistenceMappingParser
     protected void parseLobMapping(FieldMetaData fmd) {
         Column col = new Column();
         int typeCode = fmd.isElementCollection() ? fmd.getElement().getDeclaredTypeCode() :
-                fmd.getDeclaredTypeCode();
+            fmd.getDeclaredTypeCode();
         Class<?> type = fmd.isElementCollection() ? fmd.getElement().getDeclaredType() :
-                fmd.getDeclaredType();
+            fmd.getDeclaredType();
 
         if (typeCode == JavaTypes.STRING
                 || type == char[].class
@@ -1324,7 +1324,7 @@ public class AnnotationPersistenceMappingParser
     protected void parseMemberMappingAnnotations(FieldMetaData fmd) {
         FieldMapping fm = (FieldMapping) fmd;
         AnnotatedElement el = (AnnotatedElement) getRepository().
-                getMetaDataFactory().getDefaults().getBackingMember(fmd);
+            getMetaDataFactory().getDefaults().getBackingMember(fmd);
 
         MappingTag tag;
         for (Annotation anno : el.getDeclaredAnnotations()) {
@@ -1340,14 +1340,14 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case ASSOC_OVERRIDES:
                     parseAssociationOverrides(fm, ((AssociationOverrides) anno).
-                            value());
+                        value());
                     break;
                 case ATTR_OVERRIDE:
                     parseAttributeOverrides(fm, (AttributeOverride) anno);
                     break;
                 case ATTR_OVERRIDES:
                     parseAttributeOverrides(fm, ((AttributeOverrides) anno).
-                            value());
+                        value());
                     break;
                 case COL:
                     parseColumns(fm, (jakarta.persistence.Column) anno);
@@ -1369,7 +1369,7 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case KEY_CLASS_CRIT:
                     fm.getKeyMapping().getValueInfo().setUseClassCriteria
-                            (((KeyClassCriteria) anno).value());
+                        (((KeyClassCriteria) anno).value());
                     break;
                 case KEY_COL:
                     parseKeyColumns(fm, (KeyColumn) anno);
@@ -1380,20 +1380,20 @@ public class AnnotationPersistenceMappingParser
                 case KEY_EMBEDDED_MAPPING:
                     KeyEmbeddedMapping kembed = (KeyEmbeddedMapping) anno;
                     parseEmbeddedMapping(fm.getKeyMapping(),
-                            DBIdentifier.newColumn(kembed.nullIndicatorColumnName(), delimit()),
-                            DBIdentifier.newConstant(kembed.nullIndicatorAttributeName()),
-                            kembed.overrides());
+                        DBIdentifier.newColumn(kembed.nullIndicatorColumnName(), delimit()),
+                        DBIdentifier.newConstant(kembed.nullIndicatorAttributeName()),
+                        kembed.overrides());
                     break;
                 case KEY_FK:
                     KeyForeignKey kfk = (KeyForeignKey) anno;
                     parseForeignKey(fm.getKeyMapping().getValueInfo(),
-                            kfk.name(), kfk.enabled(), kfk.deferred(),
-                            kfk.deleteAction(), kfk.updateAction());
+                        kfk.name(), kfk.enabled(), kfk.deferred(),
+                        kfk.deleteAction(), kfk.updateAction());
                     break;
                 case KEY_INDEX:
                     KeyIndex kidx = (KeyIndex) anno;
                     parseIndex(fm.getKeyMapping().getValueInfo(), kidx.name(),
-                            kidx.enabled(), kidx.unique());
+                        kidx.enabled(), kidx.unique());
                     break;
                 case KEY_JOIN_COL:
                     parseKeyJoinColumns(fm, (KeyJoinColumn) anno);
@@ -1403,11 +1403,11 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case KEY_NONPOLY:
                     fm.getKeyMapping().setPolymorphic(toPolymorphicConstant
-                            (((KeyNonpolymorphic) anno).value()));
+                        (((KeyNonpolymorphic) anno).value()));
                     break;
                 case KEY_STRAT:
                     fm.getKeyMapping().getValueInfo()
-                            .setStrategy(((KeyStrategy) anno).value());
+                        .setStrategy(((KeyStrategy) anno).value());
                     break;
                 case MAP_KEY_COL:
                     parseMapKeyColumn(fm, (MapKeyColumn) anno);
@@ -1420,15 +1420,15 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case MAP_KEY_JOIN_COLS:
                     parseMapKeyJoinColumns(fm,
-                            ((MapKeyJoinColumns) anno).value());
+                        ((MapKeyJoinColumns) anno).value());
                     break;
                 case PK_JOIN_COL:
                     parsePrimaryKeyJoinColumns(fm, (PrimaryKeyJoinColumn) anno);
                     break;
                 case PK_JOIN_COLS:
                     parsePrimaryKeyJoinColumns(fm,
-                            ((PrimaryKeyJoinColumns) anno).
-                                    value());
+                        ((PrimaryKeyJoinColumns) anno).
+                            value());
                     break;
                 case TABLE_GEN:
                     parseTableGenerator(el, (TableGenerator) anno);
@@ -1446,7 +1446,7 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case CLASS_CRIT:
                     fm.getValueInfo().setUseClassCriteria
-                            (((ClassCriteria) anno).value());
+                        (((ClassCriteria) anno).value());
                     break;
                 case CONTAINER_TABLE:
                     parseContainerTable(fm, (ContainerTable) anno);
@@ -1456,11 +1456,11 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case EAGER_FETCH_MODE:
                     fm.setEagerFetchMode(toEagerFetchModeConstant
-                            (((EagerFetchMode) anno).value()));
+                        (((EagerFetchMode) anno).value()));
                     break;
                 case ELEM_CLASS_CRIT:
                     fm.getElementMapping().getValueInfo().setUseClassCriteria
-                            (((ElementClassCriteria) anno).value());
+                        (((ElementClassCriteria) anno).value());
                     break;
                 case ELEM_COL:
                     parseElementColumns(fm, (ElementColumn) anno);
@@ -1471,35 +1471,35 @@ public class AnnotationPersistenceMappingParser
                 case ELEM_EMBEDDED_MAPPING:
                     ElementEmbeddedMapping ee = (ElementEmbeddedMapping) anno;
                     parseEmbeddedMapping(fm.getElementMapping(),
-                            DBIdentifier.newConstant(ee.nullIndicatorAttributeName()),
-                            DBIdentifier.newColumn(ee.nullIndicatorColumnName(), delimit()),
-                            ee.overrides());
+                        DBIdentifier.newConstant(ee.nullIndicatorAttributeName()),
+                        DBIdentifier.newColumn(ee.nullIndicatorColumnName(), delimit()),
+                        ee.overrides());
                     break;
                 case ELEM_FK:
                     ElementForeignKey efk = (ElementForeignKey) anno;
                     parseForeignKey(fm.getElementMapping().getValueInfo(),
-                            efk.name(), efk.enabled(), efk.deferred(),
-                            efk.deleteAction(), efk.updateAction());
+                        efk.name(), efk.enabled(), efk.deferred(),
+                        efk.deleteAction(), efk.updateAction());
                     break;
                 case ELEM_INDEX:
                     ElementIndex eidx = (ElementIndex) anno;
                     parseIndex(fm.getElementMapping().getValueInfo(),
-                            eidx.name(), eidx.enabled(), eidx.unique());
+                        eidx.name(), eidx.enabled(), eidx.unique());
                     break;
                 case ELEM_JOIN_COL:
                     parseElementJoinColumns(fm, (ElementJoinColumn) anno);
                     break;
                 case ELEM_JOIN_COLS:
                     parseElementJoinColumns(fm, ((ElementJoinColumns) anno).
-                            value());
+                        value());
                     break;
                 case ELEM_NONPOLY:
                     fm.getElementMapping().setPolymorphic(toPolymorphicConstant
-                            (((ElementNonpolymorphic) anno).value()));
+                        (((ElementNonpolymorphic) anno).value()));
                     break;
                 case ELEM_STRAT:
                     fm.getElementMapping().getValueInfo()
-                            .setStrategy(((ElementStrategy) anno).value());
+                        .setStrategy(((ElementStrategy) anno).value());
                     break;
                 case EMBEDDED_MAPPING:
                     parseEmbeddedMapping(fm, (EmbeddedMapping) anno);
@@ -1512,7 +1512,7 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case NONPOLY:
                     fm.setPolymorphic(toPolymorphicConstant
-                            (((Nonpolymorphic) anno).value()));
+                        (((Nonpolymorphic) anno).value()));
                     break;
                 case ORDER_COLUMN:
                     parseJakartaOrderColumn(fm, (jakarta.persistence.OrderColumn)anno);
@@ -1525,24 +1525,24 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case UNIQUE:
                     parseUnique(fm,
-                            (org.apache.openjpa.persistence.jdbc.Unique) anno);
+                        (org.apache.openjpa.persistence.jdbc.Unique) anno);
                     break;
                 case X_EMBEDDED_MAPPING:
                     XEmbeddedMapping embed = (XEmbeddedMapping) anno;
                     parseEmbeddedMapping(fm, DBIdentifier.newColumn(embed.nullIndicatorColumnName(), delimit()),
-                            DBIdentifier.newConstant(embed.nullIndicatorAttributeName()), embed.overrides());
+                        DBIdentifier.newConstant(embed.nullIndicatorAttributeName()), embed.overrides());
                     break;
                 case X_JOIN_COL:
                     parseXJoinColumns(fm, fm.getValueInfo(), true,
-                            (XJoinColumn) anno);
+                        (XJoinColumn) anno);
                     break;
                 case X_JOIN_COLS:
                     parseXJoinColumns(fm, fm.getValueInfo(), true,
-                            ((XJoinColumns) anno).value());
+                        ((XJoinColumns) anno).value());
                     break;
                 default:
                     throw new UnsupportedException(_loc.get("unsupported", fm,
-                            anno.toString()));
+                        anno.toString()));
             }
         }
     }
@@ -1551,7 +1551,7 @@ public class AnnotationPersistenceMappingParser
      * Allow subclasses to handle unknown annotations.
      */
     protected boolean handleUnknownMemberMappingAnnotation(FieldMapping fm,
-            Annotation anno) {
+        Annotation anno) {
         return false;
     }
 
@@ -1576,7 +1576,7 @@ public class AnnotationPersistenceMappingParser
      * Parse given @AssociationOverride annotations on an embedded mapping.
      */
     private void parseAssociationOverrides(FieldMapping fm,
-            AssociationOverride... assocs) {
+        AssociationOverride... assocs) {
 
         FieldMapping efm;
         JoinColumn[] ecols;
@@ -1587,12 +1587,12 @@ public class AnnotationPersistenceMappingParser
             efm = getEmbeddedFieldMapping(fm, assoc.name());
             if (efm == null)
                 throw new MetaDataException(_loc.get("embed-override-name",
-                        fm, assoc.name()));
+                    fm, assoc.name()));
             ecols = assoc.joinColumns();
             joinTbl = assoc.joinTable();
             if ((ecols == null || ecols.length == 0) && joinTbl == null)
                 throw new MetaDataException(_loc.get("embed-override-name",
-                        fm, assoc.name()));
+                    fm, assoc.name()));
             if (ecols != null && ecols.length > 0) {
                 unique = 0;
                 jcols = new ArrayList<>(ecols.length);
@@ -1611,7 +1611,7 @@ public class AnnotationPersistenceMappingParser
      * Parse given @AttributeOverride annotations on an embedded mapping.
      */
     private void parseAttributeOverrides(FieldMapping fm,
-            AttributeOverride... attrs) {
+        AttributeOverride... attrs) {
         for (AttributeOverride attr : attrs) {
             String attrName = attr.name();
             FieldMapping efm = getEmbeddedFieldMapping(fm, attrName);
@@ -1621,7 +1621,7 @@ public class AnnotationPersistenceMappingParser
     }
 
     public static FieldMapping getEmbeddedFieldMapping(FieldMapping fm,
-            String attrName) {
+        String attrName) {
         return getEmbeddedFieldMapping(fm, attrName, true);
     }
 
@@ -1642,7 +1642,7 @@ public class AnnotationPersistenceMappingParser
             case JavaTypes.COLLECTION : // a collection of embeddables
                 if (isKey || isValue)
                     throw new MetaDataException(_loc.get("embed-override-name",
-                            fm, attrName));
+                        fm, attrName));
                 embed = fm.getElementMapping().getEmbeddedMapping();
                 break;
             case JavaTypes.MAP: // a map
@@ -1652,12 +1652,12 @@ public class AnnotationPersistenceMappingParser
                     // Per JPA spec, unqualified attribute override names
                     // (and "value." prefixed names) refer to the map value
                     embed = getEmbeddedMapping(fm.getElementMapping(),
-                            mustExist);
+                        mustExist);
                 break;
             default: // an embeddable
                 if (isKey || isValue)
                     throw new MetaDataException(_loc.get("embed-override-name",
-                            fm, attrName));
+                        fm, attrName));
                 embed = getEmbeddedMapping(fm.getValueMapping(), mustExist);
                 break;
         }
@@ -1671,7 +1671,7 @@ public class AnnotationPersistenceMappingParser
     }
 
     public static Class<?> getEmbeddedClassType(FieldMapping fm,
-            String attrName) {
+        String attrName) {
         ValueMapping embed = null;
         boolean isKey = false;
         boolean isValue = false;
@@ -1687,7 +1687,7 @@ public class AnnotationPersistenceMappingParser
             case JavaTypes.COLLECTION : // a collection of embeddables
                 if (isKey || isValue)
                     throw new MetaDataException(_loc.get("embed-override-name",
-                            fm, attrName));
+                        fm, attrName));
                 embed = fm.getElementMapping();
                 break;
             case JavaTypes.MAP: // a map
@@ -1701,7 +1701,7 @@ public class AnnotationPersistenceMappingParser
             default: // an embeddable
                 if (isKey || isValue)
                     throw new MetaDataException(_loc.get("embed-override-name",
-                            fm, attrName));
+                        fm, attrName));
                 embed = fm.getValueMapping();
                 break;
         }
@@ -1713,7 +1713,7 @@ public class AnnotationPersistenceMappingParser
     }
 
     public static ClassMapping getEmbeddedMapping(ValueMapping val, boolean
-            createNew) {
+        createNew) {
         ClassMapping embed = val.getEmbeddedMapping();
         if (embed != null || !createNew)
             return embed;
@@ -1735,7 +1735,7 @@ public class AnnotationPersistenceMappingParser
             efm = embed.getFieldMapping(attrName);
             if (efm == null)
                 throw new MetaDataException(_loc.get("embed-override-name",
-                        fm, attrName));
+                    fm, attrName));
             return efm;
         }
         String attrName1 = attrName.substring(0, idxOfDot);
@@ -1743,7 +1743,7 @@ public class AnnotationPersistenceMappingParser
         efm = embed.getFieldMapping(attrName1);
         if (efm == null)
             throw new MetaDataException(_loc.get("embed-override-name",
-                    fm, attrName1));
+                fm, attrName1));
         ClassMapping embed1 = getEmbeddedMapping(efm.getValueMapping());
         return getAttributeOverrideField(attrName2, efm, embed1);
     }
@@ -1793,7 +1793,7 @@ public class AnnotationPersistenceMappingParser
         List<Column> cols = fm.getValueInfo().getColumns();
         if (!cols.isEmpty() && cols.size() != 1)
             throw new MetaDataException(_loc.get("num-cols-mismatch", fm,
-                    String.valueOf(cols.size()), "1"));
+                String.valueOf(cols.size()), "1"));
         if (cols.isEmpty()) {
             cols = List.of(new Column());
             if (fm.isElementCollection()) {
@@ -1826,7 +1826,7 @@ public class AnnotationPersistenceMappingParser
         List<Column> cols = fm.getKeyMapping().getValueInfo().getColumns();
         if (!cols.isEmpty() && cols.size() != 1)
             throw new MetaDataException(_loc.get("num-cols-mismatch", fm,
-                    String.valueOf(cols.size()), "1"));
+                String.valueOf(cols.size()), "1"));
         if (cols.isEmpty()) {
             cols = List.of(new Column());
             fm.getKeyMapping().getValueInfo().setColumns(cols);
@@ -1850,7 +1850,7 @@ public class AnnotationPersistenceMappingParser
      * Parse @Column(s).
      */
     protected void parseColumns(FieldMapping fm,
-            jakarta.persistence.Column... pcols) {
+        jakarta.persistence.Column... pcols) {
         if (pcols.length == 0)
             return;
 
@@ -1858,7 +1858,7 @@ public class AnnotationPersistenceMappingParser
         List<Column> cols = fm.getValueInfo().getColumns();
         if (!cols.isEmpty() && cols.size() != pcols.length)
             throw new MetaDataException(_loc.get("num-cols-mismatch", fm,
-                    String.valueOf(cols.size()), String.valueOf(pcols.length)));
+                String.valueOf(cols.size()), String.valueOf(pcols.length)));
 
         // cache the JAXB XmlRootElement class if it is present so we do not
         // have a hard-wired dependency on JAXB here
@@ -1879,10 +1879,10 @@ public class AnnotationPersistenceMappingParser
                 cols.add(newColumn(pcols[i], delimit()));
             }
             if (xmlRootElementClass != null
-                    && StringUtil.isEmpty(pcols[i].columnDefinition())
+                && StringUtil.isEmpty(pcols[i].columnDefinition())
                 && fm.getDeclaredType().isAnnotationPresent(xmlRootElementClass)) {
                 DBDictionary dict = ((MappingRepository) getRepository())
-                        .getDBDictionary();
+                    .getDBDictionary();
                 if (dict.supportsXMLColumn)
                     // column maps to xml type
                     cols.get(i).setTypeIdentifier(DBIdentifier.newColumnDefinition(dict.xmlTypeName));
@@ -1890,7 +1890,7 @@ public class AnnotationPersistenceMappingParser
 
             unique |= (pcols[i].unique()) ? TRUE : FALSE;
             DBIdentifier sSecTable = DBIdentifier.newTable(pcols[i].table(), delimit());
-            sSecondary = trackSecondaryTable(fm, sSecondary, sSecTable, i);
+        	sSecondary = trackSecondaryTable(fm, sSecondary, sSecTable, i);
         }
 
         if (fm.isElementCollection())
@@ -1905,7 +1905,7 @@ public class AnnotationPersistenceMappingParser
      * Create a new schema column with information from the given annotation.
      */
     private static Column newColumn(jakarta.persistence.Column anno,
-            boolean delimit) {
+        boolean delimit) {
         Column col = new Column();
         setupColumn(col, anno, delimit);
         return col;
@@ -1915,7 +1915,7 @@ public class AnnotationPersistenceMappingParser
      * Setup the given column with information from the given annotation.
      */
     private static void setupColumn(Column col, jakarta.persistence.Column anno,
-            boolean delimit) {
+        boolean delimit) {
         if (!StringUtil.isEmpty(anno.name()))
             col.setIdentifier(DBIdentifier.newColumn(anno.name(),delimit));
         if (!StringUtil.isEmpty(anno.columnDefinition()))
@@ -1941,7 +1941,7 @@ public class AnnotationPersistenceMappingParser
      * unique attribute of each column
      */
     protected void setColumns(FieldMapping fm, MappingInfo info,
-            List<Column> cols, int unique) {
+        List<Column> cols, int unique) {
         info.setColumns(cols);
         if (unique == TRUE)
             info.setUnique(new org.apache.openjpa.jdbc.schema.Unique());
@@ -1960,7 +1960,7 @@ public class AnnotationPersistenceMappingParser
      * @return secondary table for field
      */
     private DBIdentifier trackSecondaryTable(FieldMapping fm, DBIdentifier secondary,
-            DBIdentifier colSecondary, int col) {
+        DBIdentifier colSecondary, int col) {
         if (DBIdentifier.isEmpty(colSecondary))
             colSecondary = DBIdentifier.NULL;
         if (col == 0)
@@ -1974,14 +1974,14 @@ public class AnnotationPersistenceMappingParser
      * Parse @JoinTable.
      */
     private void parseJoinTable(FieldMapping fm, JoinTable join) {
-        FieldMappingInfo info = fm.getMappingInfo();
-        DBIdentifier joinTbl = toTableIdentifier(join.schema(), join.name());
+    	FieldMappingInfo info = fm.getMappingInfo();
+    	DBIdentifier joinTbl = toTableIdentifier(join.schema(), join.name());
         info.setTableIdentifier(joinTbl);
         parseJoinColumns(fm, info, false, join.joinColumns());
         parseJoinColumns(fm, fm.getElementMapping().getValueInfo(), false,
-                join.inverseJoinColumns());
+            join.inverseJoinColumns());
         addUniqueConstraints(info.getTableIdentifier().getName(), fm, info,
-                join.uniqueConstraints());
+            join.uniqueConstraints());
         // Parse JPA @ForeignKey annotations on join table
         parseJpaForeignKey(info, join.foreignKey());
         parseJpaForeignKey(fm.getElementMapping().getValueInfo(),
@@ -1994,7 +1994,7 @@ public class AnnotationPersistenceMappingParser
      * Parse given @JoinColumn annotations.
      */
     private void parseJoinColumns(FieldMapping fm, MappingInfo info,
-            boolean secondaryAllowed, JoinColumn... joins) {
+        boolean secondaryAllowed, JoinColumn... joins) {
         if (joins.length == 0)
             return;
 
@@ -2063,7 +2063,7 @@ public class AnnotationPersistenceMappingParser
             col.setTypeIdentifier(DBIdentifier.newColumnDefinition(join.columnDefinition()));
         String refColumnName = join.referencedColumnName();
         if (!StringUtil.isEmpty(refColumnName)) {
-            setTargetIdentifier(col, refColumnName);
+        	setTargetIdentifier(col, refColumnName);
         }
         col.setNotNull(!join.nullable());
         col.setFlag(Column.FLAG_UNINSERTABLE, !join.insertable());
@@ -2081,11 +2081,11 @@ public class AnnotationPersistenceMappingParser
      */
     private static final char SINGLE_QUOTE = '\'';
     protected void setTargetIdentifier(Column col, String refColumnName) {
-        if (refColumnName.charAt(0) == SINGLE_QUOTE) {
-            col.setTargetIdentifier(DBIdentifier.newConstant(refColumnName));
-        } else {
-            col.setTargetIdentifier(DBIdentifier.newColumn(refColumnName, delimit()));
-        }
+    	if (refColumnName.charAt(0) == SINGLE_QUOTE) {
+    		col.setTargetIdentifier(DBIdentifier.newConstant(refColumnName));
+    	} else {
+    		col.setTargetIdentifier(DBIdentifier.newColumn(refColumnName, delimit()));
+    	}
     }
 
     /**
@@ -2128,7 +2128,7 @@ public class AnnotationPersistenceMappingParser
      * Parse given @PrimaryKeyJoinColumn annotations.
      */
     private void parsePrimaryKeyJoinColumns(FieldMapping fm,
-            PrimaryKeyJoinColumn... joins) {
+        PrimaryKeyJoinColumn... joins) {
         List<Column> cols = new ArrayList<>(joins.length);
         for (PrimaryKeyJoinColumn join : joins)
             cols.add(newColumn(join));
@@ -2139,7 +2139,7 @@ public class AnnotationPersistenceMappingParser
      * Parse given @XJoinColumn annotations.
      */
     protected void parseXJoinColumns(FieldMapping fm, MappingInfo info,
-            boolean secondaryAllowed, XJoinColumn... joins) {
+        boolean secondaryAllowed, XJoinColumn... joins) {
         if (joins.length == 0)
             return;
 
@@ -2150,7 +2150,7 @@ public class AnnotationPersistenceMappingParser
             cols.add(newColumn(joins[i], delimit()));
             unique |= (joins[i].unique()) ? TRUE : FALSE;
             sSecondary = trackSecondaryTable(fm, sSecondary,
-                    DBIdentifier.newTable(joins[i].table(), delimit()), i);
+                DBIdentifier.newTable(joins[i].table(), delimit()), i);
             if (!secondaryAllowed && !DBIdentifier.isNull(sSecondary))
                 throw new MetaDataException(_loc.get("bad-second", fm));
         }
@@ -2192,7 +2192,7 @@ public class AnnotationPersistenceMappingParser
             efm = embed.getFieldMapping(over.name());
             if (efm == null)
                 throw new MetaDataException(_loc.get("embed-override-name",
-                        fm, over.name()));
+                    fm, over.name()));
             populate(efm, over);
         }
 
@@ -2212,8 +2212,8 @@ public class AnnotationPersistenceMappingParser
      * Parse embedded info for the given mapping.
      */
     private void parseEmbeddedMapping(ValueMapping vm,
-            DBIdentifier nullIndicatorAttribute, DBIdentifier nullIndicatorColumn,
-            XMappingOverride[] overrides) {
+        DBIdentifier nullIndicatorAttribute, DBIdentifier nullIndicatorColumn,
+        XMappingOverride[] overrides) {
         ClassMapping embed = vm.getEmbeddedMapping();
         if (embed == null)
             throw new MetaDataException(_loc.get("not-embedded", vm));
@@ -2223,7 +2223,7 @@ public class AnnotationPersistenceMappingParser
             efm = embed.getFieldMapping(over.name());
             if (efm == null)
                 throw new MetaDataException(_loc.get("embed-override-name",
-                        vm, over.name()));
+                    vm, over.name()));
             populate(efm, over);
         }
 
@@ -2273,7 +2273,7 @@ public class AnnotationPersistenceMappingParser
         //ctbl.catalog()
         parseJoinColumns(fm, fm.getMappingInfo(), false, ctbl.joinColumns());
         addUniqueConstraints(info.getTableIdentifier().getName(), fm.getDefiningMetaData(),
-                info, ctbl.uniqueConstraints());
+            info, ctbl.uniqueConstraints());
     }
 
     /**
@@ -2318,7 +2318,7 @@ public class AnnotationPersistenceMappingParser
      * Parse @ElementJoinColumn(s).
      */
     protected void parseElementJoinColumns(FieldMapping fm,
-            ElementJoinColumn... joins) {
+        ElementJoinColumn... joins) {
         if (joins.length == 0)
             return;
 
@@ -2346,9 +2346,9 @@ public class AnnotationPersistenceMappingParser
             col.setTargetField(join.referencedAttributeName());
         col.setNotNull(!join.nullable());
         col.setFlag (Column.FLAG_UNINSERTABLE, !join.insertable ());
-        col.setFlag (Column.FLAG_UNUPDATABLE, !join.updatable ());
-        return col;
-    }
+		col.setFlag (Column.FLAG_UNUPDATABLE, !join.updatable ());
+		return col;
+	}
 
     /**
      * Parse @MapKeyColumn.
@@ -2369,7 +2369,7 @@ public class AnnotationPersistenceMappingParser
      * Setup the given column with information from the given annotation.
      */
     private void setupMapKeyColumn(FieldMapping fm, Column col,
-            MapKeyColumn anno) {
+        MapKeyColumn anno) {
         if (!StringUtil.isEmpty(anno.name())) {
             col.setIdentifier(DBIdentifier.newColumn(anno.name(), delimit()));
         }
@@ -2394,7 +2394,7 @@ public class AnnotationPersistenceMappingParser
      * unique attribute of the column
      */
     protected void setMapKeyColumn(FieldMapping fm, MappingInfo info,
-            Column col, int unique) {
+        Column col, int unique) {
         List<Column> cols = new ArrayList<>();
         cols.add(col);
         info.setColumns(cols);

--- a/openjpa-persistence-jdbc/src/main/java/org/apache/openjpa/persistence/jdbc/AnnotationPersistenceMappingParser.java
+++ b/openjpa-persistence-jdbc/src/main/java/org/apache/openjpa/persistence/jdbc/AnnotationPersistenceMappingParser.java
@@ -193,16 +193,16 @@ import jakarta.persistence.UniqueConstraint;
  * @author Abe White
  */
 public class AnnotationPersistenceMappingParser
-    extends AnnotationPersistenceMetaDataParser {
+        extends AnnotationPersistenceMetaDataParser {
 
     protected static final int TRUE = 1;
     protected static final int FALSE = 2;
 
     private static final Localizer _loc = Localizer.forPackage
-        (AnnotationPersistenceMappingParser.class);
+            (AnnotationPersistenceMappingParser.class);
 
     private static final Map<Class<?>, MappingTag> _tags =
-        new HashMap<>();
+            new HashMap<>();
 
     private final DBDictionary _dict;
 
@@ -314,7 +314,7 @@ public class AnnotationPersistenceMappingParser
                     break;
                 default:
                     throw new UnsupportedException(_loc.get("unsupported", pkg,
-                        anno.toString()));
+                            anno.toString()));
             }
         }
     }
@@ -323,7 +323,7 @@ public class AnnotationPersistenceMappingParser
      * Allow subclasses to handle unknown annotations.
      */
     protected boolean handleUnknownPackageMappingAnnotation(Package pkg,
-        Annotation anno) {
+            Annotation anno) {
         return false;
     }
 
@@ -340,7 +340,7 @@ public class AnnotationPersistenceMappingParser
             log.trace(_loc.get("parse-gen", name));
 
         SequenceMapping meta = (SequenceMapping) getRepository().
-            getCachedSequenceMetaData(name);
+                getCachedSequenceMetaData(name);
         if (meta != null) {
             if (log.isWarnEnabled())
                 log.warn(_loc.get("dup-gen", name, el));
@@ -356,19 +356,19 @@ public class AnnotationPersistenceMappingParser
         meta.setInitialValue(gen.initialValue());
         meta.setAllocate(gen.allocationSize());
         meta.setSource(getSourceFile(), (el instanceof Class) ? el : null,
-            SourceTracker.SRC_ANNOTATIONS);
+                SourceTracker.SRC_ANNOTATIONS);
 
         switch (gen.uniqueConstraints().length) {
-        case 0:
-        	break; // nothing to do
-        case 1:
-        	meta.setUniqueColumnsIdentifier(DBIdentifier.toArray(gen.uniqueConstraints()[0].columnNames(),
-        	    DBIdentifierType.COLUMN, delimit()));
-        	meta.setUniqueConstraintIdentifier(DBIdentifier.newConstraint(gen.uniqueConstraints()[0].name(),
-        	    delimit()));
-        	break;
-        default:
-        	log.warn(_loc.get("unique-many-on-seq-unsupported", el, name));
+            case 0:
+                break; // nothing to do
+            case 1:
+                meta.setUniqueColumnsIdentifier(DBIdentifier.toArray(gen.uniqueConstraints()[0].columnNames(),
+                        DBIdentifierType.COLUMN, delimit()));
+                meta.setUniqueConstraintIdentifier(DBIdentifier.newConstraint(gen.uniqueConstraints()[0].name(),
+                        delimit()));
+                break;
+            default:
+                log.warn(_loc.get("unique-many-on-seq-unsupported", el, name));
         }
     }
 
@@ -391,26 +391,26 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case ASSOC_OVERRIDES:
                     parseAssociationOverrides(cm, ((AssociationOverrides) anno).
-                        value());
+                            value());
                     break;
                 case ATTR_OVERRIDE:
                     parseAttributeOverrides(cm, (AttributeOverride) anno);
                     break;
                 case ATTR_OVERRIDES:
                     parseAttributeOverrides(cm, ((AttributeOverrides) anno).
-                        value());
+                            value());
                     break;
                 case DISCRIM_COL:
                     parseDiscriminatorColumn(cm, (DiscriminatorColumn) anno);
                     break;
                 case DISCRIM_VAL:
                     cm.getDiscriminator().getMappingInfo().setValue
-                        (((DiscriminatorValue) anno).value());
+                            (((DiscriminatorValue) anno).value());
                     if (Modifier.isAbstract(cm.getDescribedType().
                             getModifiers()) && getLog().isInfoEnabled()) {
                         getLog().info(
-                            _loc.get("discriminator-on-abstract-class", cm
-                                    .getDescribedType().getName()));
+                                _loc.get("discriminator-on-abstract-class", cm
+                                        .getDescribedType().getName()));
                     }
                     break;
                 case INHERITANCE:
@@ -421,8 +421,8 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case PK_JOIN_COLS:
                     parsePrimaryKeyJoinColumns(cm,
-                        ((PrimaryKeyJoinColumns) anno).
-                            value());
+                            ((PrimaryKeyJoinColumns) anno).
+                                    value());
                     break;
                 case SECONDARY_TABLE:
                     parseSecondaryTables(cm, (SecondaryTable) anno);
@@ -435,7 +435,7 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case SQL_RESULT_SET_MAPPINGS:
                     parseSQLResultSetMappings(cm, ((SqlResultSetMappings) anno).
-                        value());
+                            value());
                     break;
                 case TABLE:
                     parseTable(cm, (Table) anno);
@@ -453,7 +453,7 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case DISCRIM_STRAT:
                     cm.getDiscriminator().getMappingInfo().setStrategy
-                        (((DiscriminatorStrategy) anno).value());
+                            (((DiscriminatorStrategy) anno).value());
                     break;
                 case FK:
                     parseForeignKey(cm.getMappingInfo(), (ForeignKey) anno);
@@ -463,14 +463,14 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case MAPPING_OVERRIDES:
                     parseMappingOverrides(cm,
-                        ((MappingOverrides) anno).value());
+                            ((MappingOverrides) anno).value());
                     break;
                 case STRAT:
                     cm.getMappingInfo().setStrategy(((Strategy) anno).value());
                     break;
                 case SUBCLASS_FETCH_MODE:
                     cm.setSubclassFetchMode(toEagerFetchModeConstant
-                        (((SubclassFetchMode) anno).value()));
+                            (((SubclassFetchMode) anno).value()));
                     break;
                 case VERSION_COL:
                     parseVersionColumns(cm, (VersionColumn) anno);
@@ -480,14 +480,14 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case VERSION_STRAT:
                     cm.getVersion().getMappingInfo().setStrategy
-                        (((VersionStrategy) anno).value());
+                            (((VersionStrategy) anno).value());
                     break;
                 case X_MAPPING_OVERRIDE:
                     parseMappingOverrides(cm, (XMappingOverride) anno);
                     break;
                 case X_MAPPING_OVERRIDES:
                     parseMappingOverrides(cm,
-                        ((XMappingOverrides) anno).value());
+                            ((XMappingOverrides) anno).value());
                     break;
                 case X_TABLE:
                 case X_SECONDARY_TABLE:
@@ -495,7 +495,7 @@ public class AnnotationPersistenceMappingParser
                     // no break; not supported yet
                 default:
                     throw new UnsupportedException(_loc.get("unsupported", cm,
-                        anno));
+                            anno));
             }
         }
     }
@@ -504,7 +504,7 @@ public class AnnotationPersistenceMappingParser
      * Allow subclasses to handle unknown annotations.
      */
     protected boolean handleUnknownClassMappingAnnotation(ClassMapping cls,
-        Annotation anno) {
+            Annotation anno) {
         return false;
     }
 
@@ -512,7 +512,7 @@ public class AnnotationPersistenceMappingParser
      * Parse @AssociationOverride(s).
      */
     private void parseAssociationOverrides(ClassMapping cm,
-        AssociationOverride... assocs) {
+            AssociationOverride... assocs) {
         FieldMapping sup;
         JoinColumn[] scols;
         int unique;
@@ -524,7 +524,7 @@ public class AnnotationPersistenceMappingParser
             sup = (FieldMapping) cm.getDefinedSuperclassField(assoc.name());
             if (sup == null)
                 sup = (FieldMapping) cm.addDefinedSuperclassField
-                    (assoc.name(), Object.class, Object.class);
+                        (assoc.name(), Object.class, Object.class);
             scols = assoc.joinColumns();
             joinTbl = assoc.joinTable();
             if ((scols == null || scols.length == 0) && joinTbl == null)
@@ -550,7 +550,7 @@ public class AnnotationPersistenceMappingParser
      * Parse @AttributeOverride(s).
      */
     private void parseAttributeOverrides(ClassMapping cm,
-        AttributeOverride... attrs) {
+            AttributeOverride... attrs) {
         FieldMapping sup;
         for (AttributeOverride attr : attrs) {
             if (StringUtil.isEmpty(attr.name()))
@@ -569,7 +569,7 @@ public class AnnotationPersistenceMappingParser
             sup = (FieldMapping) cm.getDefinedSuperclassField(attr.name());
             if (sup == null)
                 sup = (FieldMapping) cm.addDefinedSuperclassField(attr.name(),
-                    Object.class, Object.class);
+                        Object.class, Object.class);
             if (attr.column() != null)
                 parseColumns(sup, attr.column());
         }
@@ -579,7 +579,7 @@ public class AnnotationPersistenceMappingParser
      * Parse inheritance @PrimaryKeyJoinColumn(s).
      */
     private void parsePrimaryKeyJoinColumns(ClassMapping cm,
-        PrimaryKeyJoinColumn... joins) {
+            PrimaryKeyJoinColumn... joins) {
         List<Column> cols = new ArrayList<>(joins.length);
         for (PrimaryKeyJoinColumn join : joins)
             cols.add(newColumn(join));
@@ -605,7 +605,7 @@ public class AnnotationPersistenceMappingParser
      * Parse @SecondaryTable(s).
      */
     private void parseSecondaryTables(ClassMapping cm,
-        SecondaryTable... tables) {
+            SecondaryTable... tables) {
         ClassMappingInfo info = cm.getMappingInfo();
 
         List<Column> joins = null;
@@ -623,7 +623,7 @@ public class AnnotationPersistenceMappingParser
                     joins.add(newColumn(join));
                 info.setSecondaryTableJoinColumns(sName, joins);
             } else {
-            	info.addSecondaryTable(sName);
+                info.addSecondaryTable(sName);
             }
             // Parse @ForeignKey on @SecondaryTable
             jakarta.persistence.ForeignKey jpaFk = table.foreignKey();
@@ -653,7 +653,7 @@ public class AnnotationPersistenceMappingParser
         if (!StringUtil.isEmpty(table.options()))
             cm.getMappingInfo().setTableOptions(table.options());
         addUniqueConstraints(tName.getName(), cm, cm.getMappingInfo(),
-            table.uniqueConstraints());
+                table.uniqueConstraints());
         addIndices(tName.getName(), cm, cm.getMappingInfo(), table.indexes());
     }
 
@@ -678,7 +678,7 @@ public class AnnotationPersistenceMappingParser
     }
 
     void addUniqueConstraints(String table, MetaDataContext ctx,
-        MappingInfo info, UniqueConstraint... uniqueConstraints) {
+            MappingInfo info, UniqueConstraint... uniqueConstraints) {
         for (UniqueConstraint anno : uniqueConstraints) {
             Unique unique = createUniqueConstraint(ctx, anno);
             unique.setTableIdentifier(DBIdentifier.newTable(table, delimit()));
@@ -733,7 +733,7 @@ public class AnnotationPersistenceMappingParser
     }
 
     void addIndices(String table, MetaDataContext ctx,
-        MappingInfo info, jakarta.persistence.Index... indices) {
+            MappingInfo info, jakarta.persistence.Index... indices) {
         for (jakarta.persistence.Index anno : indices) {
             org.apache.openjpa.jdbc.schema.Index idx = createIndex(ctx, anno);
             idx.setTableIdentifier(DBIdentifier.newTable(table, delimit()));
@@ -764,7 +764,7 @@ public class AnnotationPersistenceMappingParser
      * {@link SQLResultSetMappingMetaData}.
      */
     private void parseSQLResultSetMappings(ClassMapping cm,
-        SqlResultSetMapping... annos) {
+            SqlResultSetMapping... annos) {
         MappingRepository repos = (MappingRepository) getRepository();
         Log log = getLog();
         for (SqlResultSetMapping anno : annos) {
@@ -772,7 +772,7 @@ public class AnnotationPersistenceMappingParser
                 log.trace(_loc.get("parse-sqlrsmapping", anno.name()));
 
             QueryResultMapping result = repos.getCachedQueryResultMapping
-                (null, anno.name());
+                    (null, anno.name());
             if (result != null) {
                 if (log.isWarnEnabled())
                     log.warn(_loc.get("dup-sqlrsmapping", anno.name(), cm));
@@ -781,14 +781,14 @@ public class AnnotationPersistenceMappingParser
 
             result = repos.addQueryResultMapping(null, anno.name());
             result.setSource(getSourceFile(), cm.getDescribedType(),
-                SourceTracker.SRC_ANNOTATIONS);
+                    SourceTracker.SRC_ANNOTATIONS);
 
             for (EntityResult entity : anno.entities()) {
                 QueryResultMapping.PCResult entityResult = result.addPCResult
-                    (entity.entityClass());
+                        (entity.entityClass());
                 if (!StringUtil.isEmpty(entity.discriminatorColumn()))
                     entityResult.addMapping(PCResult.DISCRIMINATOR,
-                        entity.discriminatorColumn());
+                            entity.discriminatorColumn());
 
                 for (FieldResult field : entity.fields()) {
                     DBIdentifier sColName = DBIdentifier.newColumn(field.column(), delimit());
@@ -874,7 +874,7 @@ public class AnnotationPersistenceMappingParser
      * Parse @DiscriminatorColumn.
      */
     private void parseDiscriminatorColumn(ClassMapping cm,
-        DiscriminatorColumn dcol) {
+            DiscriminatorColumn dcol) {
         Column col = new Column();
         if (!StringUtil.isEmpty(dcol.name())) {
             col.setIdentifier(DBIdentifier.newColumn(dcol.name(),delimit()));
@@ -927,7 +927,7 @@ public class AnnotationPersistenceMappingParser
      * Parse class-level @MappingOverride(s).
      */
     private void parseMappingOverrides(ClassMapping cm,
-        MappingOverride... overs) {
+            MappingOverride... overs) {
         FieldMapping sup;
         for (MappingOverride over : overs) {
             if (StringUtil.isEmpty(over.name()))
@@ -935,7 +935,7 @@ public class AnnotationPersistenceMappingParser
             sup = (FieldMapping) cm.getDefinedSuperclassField(over.name());
             if (sup == null)
                 sup = (FieldMapping) cm.addDefinedSuperclassField(over.name(),
-                    Object.class, Object.class);
+                        Object.class, Object.class);
             populate(sup, over);
         }
     }
@@ -972,28 +972,28 @@ public class AnnotationPersistenceMappingParser
      * Parse the given foreign key.
      */
     private void parseForeignKey(MappingInfo info, ForeignKey fk) {
-    	if (!fk.implicit()) {
-    		parseForeignKey(info, fk.name(), fk.enabled(), fk.deferred(),
-    				fk.deleteAction(), fk.updateAction());
-    	} else {
+        if (!fk.implicit()) {
+            parseForeignKey(info, fk.name(), fk.enabled(), fk.deferred(),
+                    fk.deleteAction(), fk.updateAction());
+        } else {
             info.setImplicitRelation(true);
             assertDefault(fk);
-    	}
+        }
     }
 
     /**
      * Set foreign key data on the given mapping info.
      */
     protected void parseForeignKey(MappingInfo info, String name,
-        boolean enabled, boolean deferred, ForeignKeyAction deleteAction,
-        ForeignKeyAction updateAction) {
+            boolean enabled, boolean deferred, ForeignKeyAction deleteAction,
+            ForeignKeyAction updateAction) {
         if (!enabled) {
             info.setCanForeignKey(false);
             return;
         }
 
         org.apache.openjpa.jdbc.schema.ForeignKey fk =
-            new org.apache.openjpa.jdbc.schema.ForeignKey();
+                new org.apache.openjpa.jdbc.schema.ForeignKey();
         if (!StringUtil.isEmpty(name))
             fk.setIdentifier(DBIdentifier.newForeignKey(name, delimit()));
         fk.setDeferred(deferred);
@@ -1028,15 +1028,15 @@ public class AnnotationPersistenceMappingParser
 
     void assertDefault(ForeignKey fk) {
         boolean isDefault = StringUtil.isEmpty(fk.name())
-            && fk.enabled()
-            && !fk.deferred()
+                && fk.enabled()
+                && !fk.deferred()
                 && fk.deleteAction() == ForeignKeyAction.RESTRICT
                 && fk.updateAction() == ForeignKeyAction.RESTRICT
-            && fk.columnNames().length == 0
-            && fk.specified();
+                && fk.columnNames().length == 0
+                && fk.specified();
         if (!isDefault)
             throw new UserException(_loc.get("implicit-non-default-fk", _cls,
-                getSourceFile()).getMessage());
+                    getSourceFile()).getMessage());
     }
 
 
@@ -1063,24 +1063,40 @@ public class AnnotationPersistenceMappingParser
      * Parse the given index.
      */
     private void parseIndex(MappingInfo info, Index idx) {
-        parseIndex(info, idx.name(), idx.enabled(), idx.unique());
+    parseIndex(info, idx.name(), idx.enabled(), idx.unique(), idx.columnNames());
     }
 
     /**
      * Set index data on the given mapping info.
      */
     protected void parseIndex(MappingInfo info, String name,
-        boolean enabled, boolean unique) {
+            boolean enabled, boolean unique) {
+        parseIndex(info, name, enabled, unique, null);
+    }
+
+    /**
+     * Set index data on the given mapping info, including optional explicit column names.
+     */
+    protected void parseIndex(MappingInfo info, String name,
+            boolean enabled, boolean unique, String[] columnNames) {
         if (!enabled) {
             info.setCanIndex(false);
             return;
         }
 
         org.apache.openjpa.jdbc.schema.Index idx =
-            new org.apache.openjpa.jdbc.schema.Index();
+                new org.apache.openjpa.jdbc.schema.Index();
         if (!StringUtil.isEmpty(name))
             idx.setIdentifier(DBIdentifier.newConstraint(name, delimit()));
         idx.setUnique(unique);
+
+        if (columnNames != null) for (String columnName : columnNames) {
+            org.apache.openjpa.jdbc.schema.Column column =
+                    new org.apache.openjpa.jdbc.schema.Column();
+            column.setIdentifier(DBIdentifier.newColumn(columnName, delimit()));
+            idx.addColumn(column);
+        }
+
         info.setIndex(idx);
     }
 
@@ -1088,7 +1104,7 @@ public class AnnotationPersistenceMappingParser
      * Set unique data on the given mapping info.
      */
     private void parseUnique(FieldMapping fm,
-        org.apache.openjpa.persistence.jdbc.Unique anno) {
+            org.apache.openjpa.persistence.jdbc.Unique anno) {
         ValueMappingInfo info = fm.getValueInfo();
         if (!anno.enabled()) {
             info.setCanUnique(false);
@@ -1096,7 +1112,7 @@ public class AnnotationPersistenceMappingParser
         }
 
         org.apache.openjpa.jdbc.schema.Unique unq =
-            new org.apache.openjpa.jdbc.schema.Unique();
+                new org.apache.openjpa.jdbc.schema.Unique();
         if (!StringUtil.isEmpty(anno.name()))
             unq.setIdentifier(DBIdentifier.newIndex(anno.name(), delimit()));
         unq.setDeferred(anno.deferred());
@@ -1121,15 +1137,15 @@ public class AnnotationPersistenceMappingParser
      */
     private static Column newColumn(VersionColumn anno, boolean delimit) {
         return newColumn(anno.name(),
-            anno.nullable(),
-            anno.insertable(),
-            anno.updatable(),
-            anno.columnDefinition(),
-            anno.length(),
-            anno.precision(),
-            anno.scale(),
-            anno.table(),
-            delimit);
+                anno.nullable(),
+                anno.insertable(),
+                anno.updatable(),
+                anno.columnDefinition(),
+                anno.length(),
+                anno.precision(),
+                anno.scale(),
+                anno.table(),
+                delimit);
     }
 
     static Column newColumn(String name,
@@ -1156,7 +1172,7 @@ public class AnnotationPersistenceMappingParser
             col.setTypeIdentifier(DBIdentifier.newColumnDefinition(columnDefinition));
             col.setType(Schemas.getJDBCType(col.getTypeIdentifier().getName()));
             col.setJavaType(JavaTypes.getTypeCode(Schemas.getJavaType
-                (col.getType(), col.getSize(), col.getDecimalDigits())));
+                    (col.getType(), col.getSize(), col.getDecimalDigits())));
         }
         col.setFlag(Column.FLAG_UNINSERTABLE, !insertable);
         col.setFlag(Column.FLAG_UNUPDATABLE, !updatable);
@@ -1168,7 +1184,7 @@ public class AnnotationPersistenceMappingParser
      * Parse class-level @XMappingOverride(s).
      */
     private void parseMappingOverrides(ClassMapping cm,
-        XMappingOverride... overs) {
+            XMappingOverride... overs) {
         FieldMapping sup;
         for (XMappingOverride over : overs) {
             if (StringUtil.isEmpty(over.name()))
@@ -1176,7 +1192,7 @@ public class AnnotationPersistenceMappingParser
             sup = (FieldMapping) cm.getDefinedSuperclassField(over.name());
             if (sup == null)
                 sup = (FieldMapping) cm.addDefinedSuperclassField(over.name(),
-                    Object.class, Object.class);
+                        Object.class, Object.class);
             populate(sup, over);
         }
     }
@@ -1286,9 +1302,9 @@ public class AnnotationPersistenceMappingParser
     protected void parseLobMapping(FieldMetaData fmd) {
         Column col = new Column();
         int typeCode = fmd.isElementCollection() ? fmd.getElement().getDeclaredTypeCode() :
-            fmd.getDeclaredTypeCode();
+                fmd.getDeclaredTypeCode();
         Class<?> type = fmd.isElementCollection() ? fmd.getElement().getDeclaredType() :
-            fmd.getDeclaredType();
+                fmd.getDeclaredType();
 
         if (typeCode == JavaTypes.STRING
                 || type == char[].class
@@ -1307,7 +1323,7 @@ public class AnnotationPersistenceMappingParser
     protected void parseMemberMappingAnnotations(FieldMetaData fmd) {
         FieldMapping fm = (FieldMapping) fmd;
         AnnotatedElement el = (AnnotatedElement) getRepository().
-            getMetaDataFactory().getDefaults().getBackingMember(fmd);
+                getMetaDataFactory().getDefaults().getBackingMember(fmd);
 
         MappingTag tag;
         for (Annotation anno : el.getDeclaredAnnotations()) {
@@ -1323,14 +1339,14 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case ASSOC_OVERRIDES:
                     parseAssociationOverrides(fm, ((AssociationOverrides) anno).
-                        value());
+                            value());
                     break;
                 case ATTR_OVERRIDE:
                     parseAttributeOverrides(fm, (AttributeOverride) anno);
                     break;
                 case ATTR_OVERRIDES:
                     parseAttributeOverrides(fm, ((AttributeOverrides) anno).
-                        value());
+                            value());
                     break;
                 case COL:
                     parseColumns(fm, (jakarta.persistence.Column) anno);
@@ -1352,7 +1368,7 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case KEY_CLASS_CRIT:
                     fm.getKeyMapping().getValueInfo().setUseClassCriteria
-                        (((KeyClassCriteria) anno).value());
+                            (((KeyClassCriteria) anno).value());
                     break;
                 case KEY_COL:
                     parseKeyColumns(fm, (KeyColumn) anno);
@@ -1363,20 +1379,20 @@ public class AnnotationPersistenceMappingParser
                 case KEY_EMBEDDED_MAPPING:
                     KeyEmbeddedMapping kembed = (KeyEmbeddedMapping) anno;
                     parseEmbeddedMapping(fm.getKeyMapping(),
-                        DBIdentifier.newColumn(kembed.nullIndicatorColumnName(), delimit()),
-                        DBIdentifier.newConstant(kembed.nullIndicatorAttributeName()),
-                        kembed.overrides());
+                            DBIdentifier.newColumn(kembed.nullIndicatorColumnName(), delimit()),
+                            DBIdentifier.newConstant(kembed.nullIndicatorAttributeName()),
+                            kembed.overrides());
                     break;
                 case KEY_FK:
                     KeyForeignKey kfk = (KeyForeignKey) anno;
                     parseForeignKey(fm.getKeyMapping().getValueInfo(),
-                        kfk.name(), kfk.enabled(), kfk.deferred(),
-                        kfk.deleteAction(), kfk.updateAction());
+                            kfk.name(), kfk.enabled(), kfk.deferred(),
+                            kfk.deleteAction(), kfk.updateAction());
                     break;
                 case KEY_INDEX:
                     KeyIndex kidx = (KeyIndex) anno;
                     parseIndex(fm.getKeyMapping().getValueInfo(), kidx.name(),
-                        kidx.enabled(), kidx.unique());
+                            kidx.enabled(), kidx.unique());
                     break;
                 case KEY_JOIN_COL:
                     parseKeyJoinColumns(fm, (KeyJoinColumn) anno);
@@ -1386,11 +1402,11 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case KEY_NONPOLY:
                     fm.getKeyMapping().setPolymorphic(toPolymorphicConstant
-                        (((KeyNonpolymorphic) anno).value()));
+                            (((KeyNonpolymorphic) anno).value()));
                     break;
                 case KEY_STRAT:
                     fm.getKeyMapping().getValueInfo()
-                        .setStrategy(((KeyStrategy) anno).value());
+                            .setStrategy(((KeyStrategy) anno).value());
                     break;
                 case MAP_KEY_COL:
                     parseMapKeyColumn(fm, (MapKeyColumn) anno);
@@ -1403,15 +1419,15 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case MAP_KEY_JOIN_COLS:
                     parseMapKeyJoinColumns(fm,
-                        ((MapKeyJoinColumns) anno).value());
+                            ((MapKeyJoinColumns) anno).value());
                     break;
                 case PK_JOIN_COL:
                     parsePrimaryKeyJoinColumns(fm, (PrimaryKeyJoinColumn) anno);
                     break;
                 case PK_JOIN_COLS:
                     parsePrimaryKeyJoinColumns(fm,
-                        ((PrimaryKeyJoinColumns) anno).
-                            value());
+                            ((PrimaryKeyJoinColumns) anno).
+                                    value());
                     break;
                 case TABLE_GEN:
                     parseTableGenerator(el, (TableGenerator) anno);
@@ -1429,7 +1445,7 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case CLASS_CRIT:
                     fm.getValueInfo().setUseClassCriteria
-                        (((ClassCriteria) anno).value());
+                            (((ClassCriteria) anno).value());
                     break;
                 case CONTAINER_TABLE:
                     parseContainerTable(fm, (ContainerTable) anno);
@@ -1439,11 +1455,11 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case EAGER_FETCH_MODE:
                     fm.setEagerFetchMode(toEagerFetchModeConstant
-                        (((EagerFetchMode) anno).value()));
+                            (((EagerFetchMode) anno).value()));
                     break;
                 case ELEM_CLASS_CRIT:
                     fm.getElementMapping().getValueInfo().setUseClassCriteria
-                        (((ElementClassCriteria) anno).value());
+                            (((ElementClassCriteria) anno).value());
                     break;
                 case ELEM_COL:
                     parseElementColumns(fm, (ElementColumn) anno);
@@ -1454,35 +1470,35 @@ public class AnnotationPersistenceMappingParser
                 case ELEM_EMBEDDED_MAPPING:
                     ElementEmbeddedMapping ee = (ElementEmbeddedMapping) anno;
                     parseEmbeddedMapping(fm.getElementMapping(),
-                        DBIdentifier.newConstant(ee.nullIndicatorAttributeName()),
-                        DBIdentifier.newColumn(ee.nullIndicatorColumnName(), delimit()),
-                        ee.overrides());
+                            DBIdentifier.newConstant(ee.nullIndicatorAttributeName()),
+                            DBIdentifier.newColumn(ee.nullIndicatorColumnName(), delimit()),
+                            ee.overrides());
                     break;
                 case ELEM_FK:
                     ElementForeignKey efk = (ElementForeignKey) anno;
                     parseForeignKey(fm.getElementMapping().getValueInfo(),
-                        efk.name(), efk.enabled(), efk.deferred(),
-                        efk.deleteAction(), efk.updateAction());
+                            efk.name(), efk.enabled(), efk.deferred(),
+                            efk.deleteAction(), efk.updateAction());
                     break;
                 case ELEM_INDEX:
                     ElementIndex eidx = (ElementIndex) anno;
                     parseIndex(fm.getElementMapping().getValueInfo(),
-                        eidx.name(), eidx.enabled(), eidx.unique());
+                            eidx.name(), eidx.enabled(), eidx.unique());
                     break;
                 case ELEM_JOIN_COL:
                     parseElementJoinColumns(fm, (ElementJoinColumn) anno);
                     break;
                 case ELEM_JOIN_COLS:
                     parseElementJoinColumns(fm, ((ElementJoinColumns) anno).
-                        value());
+                            value());
                     break;
                 case ELEM_NONPOLY:
                     fm.getElementMapping().setPolymorphic(toPolymorphicConstant
-                        (((ElementNonpolymorphic) anno).value()));
+                            (((ElementNonpolymorphic) anno).value()));
                     break;
                 case ELEM_STRAT:
                     fm.getElementMapping().getValueInfo()
-                        .setStrategy(((ElementStrategy) anno).value());
+                            .setStrategy(((ElementStrategy) anno).value());
                     break;
                 case EMBEDDED_MAPPING:
                     parseEmbeddedMapping(fm, (EmbeddedMapping) anno);
@@ -1495,7 +1511,7 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case NONPOLY:
                     fm.setPolymorphic(toPolymorphicConstant
-                        (((Nonpolymorphic) anno).value()));
+                            (((Nonpolymorphic) anno).value()));
                     break;
                 case ORDER_COLUMN:
                     parseJakartaOrderColumn(fm, (jakarta.persistence.OrderColumn)anno);
@@ -1508,24 +1524,24 @@ public class AnnotationPersistenceMappingParser
                     break;
                 case UNIQUE:
                     parseUnique(fm,
-                        (org.apache.openjpa.persistence.jdbc.Unique) anno);
+                            (org.apache.openjpa.persistence.jdbc.Unique) anno);
                     break;
                 case X_EMBEDDED_MAPPING:
                     XEmbeddedMapping embed = (XEmbeddedMapping) anno;
                     parseEmbeddedMapping(fm, DBIdentifier.newColumn(embed.nullIndicatorColumnName(), delimit()),
-                        DBIdentifier.newConstant(embed.nullIndicatorAttributeName()), embed.overrides());
+                            DBIdentifier.newConstant(embed.nullIndicatorAttributeName()), embed.overrides());
                     break;
                 case X_JOIN_COL:
                     parseXJoinColumns(fm, fm.getValueInfo(), true,
-                        (XJoinColumn) anno);
+                            (XJoinColumn) anno);
                     break;
                 case X_JOIN_COLS:
                     parseXJoinColumns(fm, fm.getValueInfo(), true,
-                        ((XJoinColumns) anno).value());
+                            ((XJoinColumns) anno).value());
                     break;
                 default:
                     throw new UnsupportedException(_loc.get("unsupported", fm,
-                        anno.toString()));
+                            anno.toString()));
             }
         }
     }
@@ -1534,7 +1550,7 @@ public class AnnotationPersistenceMappingParser
      * Allow subclasses to handle unknown annotations.
      */
     protected boolean handleUnknownMemberMappingAnnotation(FieldMapping fm,
-        Annotation anno) {
+            Annotation anno) {
         return false;
     }
 
@@ -1559,7 +1575,7 @@ public class AnnotationPersistenceMappingParser
      * Parse given @AssociationOverride annotations on an embedded mapping.
      */
     private void parseAssociationOverrides(FieldMapping fm,
-        AssociationOverride... assocs) {
+            AssociationOverride... assocs) {
 
         FieldMapping efm;
         JoinColumn[] ecols;
@@ -1570,12 +1586,12 @@ public class AnnotationPersistenceMappingParser
             efm = getEmbeddedFieldMapping(fm, assoc.name());
             if (efm == null)
                 throw new MetaDataException(_loc.get("embed-override-name",
-                    fm, assoc.name()));
+                        fm, assoc.name()));
             ecols = assoc.joinColumns();
             joinTbl = assoc.joinTable();
             if ((ecols == null || ecols.length == 0) && joinTbl == null)
                 throw new MetaDataException(_loc.get("embed-override-name",
-                    fm, assoc.name()));
+                        fm, assoc.name()));
             if (ecols != null && ecols.length > 0) {
                 unique = 0;
                 jcols = new ArrayList<>(ecols.length);
@@ -1594,7 +1610,7 @@ public class AnnotationPersistenceMappingParser
      * Parse given @AttributeOverride annotations on an embedded mapping.
      */
     private void parseAttributeOverrides(FieldMapping fm,
-        AttributeOverride... attrs) {
+            AttributeOverride... attrs) {
         for (AttributeOverride attr : attrs) {
             String attrName = attr.name();
             FieldMapping efm = getEmbeddedFieldMapping(fm, attrName);
@@ -1604,7 +1620,7 @@ public class AnnotationPersistenceMappingParser
     }
 
     public static FieldMapping getEmbeddedFieldMapping(FieldMapping fm,
-        String attrName) {
+            String attrName) {
         return getEmbeddedFieldMapping(fm, attrName, true);
     }
 
@@ -1625,7 +1641,7 @@ public class AnnotationPersistenceMappingParser
             case JavaTypes.COLLECTION : // a collection of embeddables
                 if (isKey || isValue)
                     throw new MetaDataException(_loc.get("embed-override-name",
-                        fm, attrName));
+                            fm, attrName));
                 embed = fm.getElementMapping().getEmbeddedMapping();
                 break;
             case JavaTypes.MAP: // a map
@@ -1635,12 +1651,12 @@ public class AnnotationPersistenceMappingParser
                     // Per JPA spec, unqualified attribute override names
                     // (and "value." prefixed names) refer to the map value
                     embed = getEmbeddedMapping(fm.getElementMapping(),
-                        mustExist);
+                            mustExist);
                 break;
             default: // an embeddable
                 if (isKey || isValue)
                     throw new MetaDataException(_loc.get("embed-override-name",
-                        fm, attrName));
+                            fm, attrName));
                 embed = getEmbeddedMapping(fm.getValueMapping(), mustExist);
                 break;
         }
@@ -1654,7 +1670,7 @@ public class AnnotationPersistenceMappingParser
     }
 
     public static Class<?> getEmbeddedClassType(FieldMapping fm,
-        String attrName) {
+            String attrName) {
         ValueMapping embed = null;
         boolean isKey = false;
         boolean isValue = false;
@@ -1670,7 +1686,7 @@ public class AnnotationPersistenceMappingParser
             case JavaTypes.COLLECTION : // a collection of embeddables
                 if (isKey || isValue)
                     throw new MetaDataException(_loc.get("embed-override-name",
-                        fm, attrName));
+                            fm, attrName));
                 embed = fm.getElementMapping();
                 break;
             case JavaTypes.MAP: // a map
@@ -1684,7 +1700,7 @@ public class AnnotationPersistenceMappingParser
             default: // an embeddable
                 if (isKey || isValue)
                     throw new MetaDataException(_loc.get("embed-override-name",
-                        fm, attrName));
+                            fm, attrName));
                 embed = fm.getValueMapping();
                 break;
         }
@@ -1696,7 +1712,7 @@ public class AnnotationPersistenceMappingParser
     }
 
     public static ClassMapping getEmbeddedMapping(ValueMapping val, boolean
-        createNew) {
+            createNew) {
         ClassMapping embed = val.getEmbeddedMapping();
         if (embed != null || !createNew)
             return embed;
@@ -1718,7 +1734,7 @@ public class AnnotationPersistenceMappingParser
             efm = embed.getFieldMapping(attrName);
             if (efm == null)
                 throw new MetaDataException(_loc.get("embed-override-name",
-                    fm, attrName));
+                        fm, attrName));
             return efm;
         }
         String attrName1 = attrName.substring(0, idxOfDot);
@@ -1726,7 +1742,7 @@ public class AnnotationPersistenceMappingParser
         efm = embed.getFieldMapping(attrName1);
         if (efm == null)
             throw new MetaDataException(_loc.get("embed-override-name",
-                fm, attrName1));
+                    fm, attrName1));
         ClassMapping embed1 = getEmbeddedMapping(efm.getValueMapping());
         return getAttributeOverrideField(attrName2, efm, embed1);
     }
@@ -1776,7 +1792,7 @@ public class AnnotationPersistenceMappingParser
         List<Column> cols = fm.getValueInfo().getColumns();
         if (!cols.isEmpty() && cols.size() != 1)
             throw new MetaDataException(_loc.get("num-cols-mismatch", fm,
-                String.valueOf(cols.size()), "1"));
+                    String.valueOf(cols.size()), "1"));
         if (cols.isEmpty()) {
             cols = List.of(new Column());
             if (fm.isElementCollection()) {
@@ -1809,7 +1825,7 @@ public class AnnotationPersistenceMappingParser
         List<Column> cols = fm.getKeyMapping().getValueInfo().getColumns();
         if (!cols.isEmpty() && cols.size() != 1)
             throw new MetaDataException(_loc.get("num-cols-mismatch", fm,
-                String.valueOf(cols.size()), "1"));
+                    String.valueOf(cols.size()), "1"));
         if (cols.isEmpty()) {
             cols = List.of(new Column());
             fm.getKeyMapping().getValueInfo().setColumns(cols);
@@ -1833,7 +1849,7 @@ public class AnnotationPersistenceMappingParser
      * Parse @Column(s).
      */
     protected void parseColumns(FieldMapping fm,
-        jakarta.persistence.Column... pcols) {
+            jakarta.persistence.Column... pcols) {
         if (pcols.length == 0)
             return;
 
@@ -1841,7 +1857,7 @@ public class AnnotationPersistenceMappingParser
         List<Column> cols = fm.getValueInfo().getColumns();
         if (!cols.isEmpty() && cols.size() != pcols.length)
             throw new MetaDataException(_loc.get("num-cols-mismatch", fm,
-                String.valueOf(cols.size()), String.valueOf(pcols.length)));
+                    String.valueOf(cols.size()), String.valueOf(pcols.length)));
 
         // cache the JAXB XmlRootElement class if it is present so we do not
         // have a hard-wired dependency on JAXB here
@@ -1862,10 +1878,10 @@ public class AnnotationPersistenceMappingParser
                 cols.add(newColumn(pcols[i], delimit()));
             }
             if (xmlRootElementClass != null
-                && StringUtil.isEmpty(pcols[i].columnDefinition())
+                    && StringUtil.isEmpty(pcols[i].columnDefinition())
                 && fm.getDeclaredType().isAnnotationPresent(xmlRootElementClass)) {
                 DBDictionary dict = ((MappingRepository) getRepository())
-                    .getDBDictionary();
+                        .getDBDictionary();
                 if (dict.supportsXMLColumn)
                     // column maps to xml type
                     cols.get(i).setTypeIdentifier(DBIdentifier.newColumnDefinition(dict.xmlTypeName));
@@ -1873,7 +1889,7 @@ public class AnnotationPersistenceMappingParser
 
             unique |= (pcols[i].unique()) ? TRUE : FALSE;
             DBIdentifier sSecTable = DBIdentifier.newTable(pcols[i].table(), delimit());
-        	sSecondary = trackSecondaryTable(fm, sSecondary, sSecTable, i);
+            sSecondary = trackSecondaryTable(fm, sSecondary, sSecTable, i);
         }
 
         if (fm.isElementCollection())
@@ -1888,7 +1904,7 @@ public class AnnotationPersistenceMappingParser
      * Create a new schema column with information from the given annotation.
      */
     private static Column newColumn(jakarta.persistence.Column anno,
-        boolean delimit) {
+            boolean delimit) {
         Column col = new Column();
         setupColumn(col, anno, delimit);
         return col;
@@ -1898,7 +1914,7 @@ public class AnnotationPersistenceMappingParser
      * Setup the given column with information from the given annotation.
      */
     private static void setupColumn(Column col, jakarta.persistence.Column anno,
-        boolean delimit) {
+            boolean delimit) {
         if (!StringUtil.isEmpty(anno.name()))
             col.setIdentifier(DBIdentifier.newColumn(anno.name(),delimit));
         if (!StringUtil.isEmpty(anno.columnDefinition()))
@@ -1924,7 +1940,7 @@ public class AnnotationPersistenceMappingParser
      * unique attribute of each column
      */
     protected void setColumns(FieldMapping fm, MappingInfo info,
-        List<Column> cols, int unique) {
+            List<Column> cols, int unique) {
         info.setColumns(cols);
         if (unique == TRUE)
             info.setUnique(new org.apache.openjpa.jdbc.schema.Unique());
@@ -1943,7 +1959,7 @@ public class AnnotationPersistenceMappingParser
      * @return secondary table for field
      */
     private DBIdentifier trackSecondaryTable(FieldMapping fm, DBIdentifier secondary,
-        DBIdentifier colSecondary, int col) {
+            DBIdentifier colSecondary, int col) {
         if (DBIdentifier.isEmpty(colSecondary))
             colSecondary = DBIdentifier.NULL;
         if (col == 0)
@@ -1957,14 +1973,14 @@ public class AnnotationPersistenceMappingParser
      * Parse @JoinTable.
      */
     private void parseJoinTable(FieldMapping fm, JoinTable join) {
-    	FieldMappingInfo info = fm.getMappingInfo();
-    	DBIdentifier joinTbl = toTableIdentifier(join.schema(), join.name());
+        FieldMappingInfo info = fm.getMappingInfo();
+        DBIdentifier joinTbl = toTableIdentifier(join.schema(), join.name());
         info.setTableIdentifier(joinTbl);
         parseJoinColumns(fm, info, false, join.joinColumns());
         parseJoinColumns(fm, fm.getElementMapping().getValueInfo(), false,
-            join.inverseJoinColumns());
+                join.inverseJoinColumns());
         addUniqueConstraints(info.getTableIdentifier().getName(), fm, info,
-            join.uniqueConstraints());
+                join.uniqueConstraints());
         // Parse JPA @ForeignKey annotations on join table
         parseJpaForeignKey(info, join.foreignKey());
         parseJpaForeignKey(fm.getElementMapping().getValueInfo(),
@@ -1977,7 +1993,7 @@ public class AnnotationPersistenceMappingParser
      * Parse given @JoinColumn annotations.
      */
     private void parseJoinColumns(FieldMapping fm, MappingInfo info,
-        boolean secondaryAllowed, JoinColumn... joins) {
+            boolean secondaryAllowed, JoinColumn... joins) {
         if (joins.length == 0)
             return;
 
@@ -2046,7 +2062,7 @@ public class AnnotationPersistenceMappingParser
             col.setTypeIdentifier(DBIdentifier.newColumnDefinition(join.columnDefinition()));
         String refColumnName = join.referencedColumnName();
         if (!StringUtil.isEmpty(refColumnName)) {
-        	setTargetIdentifier(col, refColumnName);
+            setTargetIdentifier(col, refColumnName);
         }
         col.setNotNull(!join.nullable());
         col.setFlag(Column.FLAG_UNINSERTABLE, !join.insertable());
@@ -2064,11 +2080,11 @@ public class AnnotationPersistenceMappingParser
      */
     private static final char SINGLE_QUOTE = '\'';
     protected void setTargetIdentifier(Column col, String refColumnName) {
-    	if (refColumnName.charAt(0) == SINGLE_QUOTE) {
-    		col.setTargetIdentifier(DBIdentifier.newConstant(refColumnName));
-    	} else {
-    		col.setTargetIdentifier(DBIdentifier.newColumn(refColumnName, delimit()));
-    	}
+        if (refColumnName.charAt(0) == SINGLE_QUOTE) {
+            col.setTargetIdentifier(DBIdentifier.newConstant(refColumnName));
+        } else {
+            col.setTargetIdentifier(DBIdentifier.newColumn(refColumnName, delimit()));
+        }
     }
 
     /**
@@ -2111,7 +2127,7 @@ public class AnnotationPersistenceMappingParser
      * Parse given @PrimaryKeyJoinColumn annotations.
      */
     private void parsePrimaryKeyJoinColumns(FieldMapping fm,
-        PrimaryKeyJoinColumn... joins) {
+            PrimaryKeyJoinColumn... joins) {
         List<Column> cols = new ArrayList<>(joins.length);
         for (PrimaryKeyJoinColumn join : joins)
             cols.add(newColumn(join));
@@ -2122,7 +2138,7 @@ public class AnnotationPersistenceMappingParser
      * Parse given @XJoinColumn annotations.
      */
     protected void parseXJoinColumns(FieldMapping fm, MappingInfo info,
-        boolean secondaryAllowed, XJoinColumn... joins) {
+            boolean secondaryAllowed, XJoinColumn... joins) {
         if (joins.length == 0)
             return;
 
@@ -2133,7 +2149,7 @@ public class AnnotationPersistenceMappingParser
             cols.add(newColumn(joins[i], delimit()));
             unique |= (joins[i].unique()) ? TRUE : FALSE;
             sSecondary = trackSecondaryTable(fm, sSecondary,
-                DBIdentifier.newTable(joins[i].table(), delimit()), i);
+                    DBIdentifier.newTable(joins[i].table(), delimit()), i);
             if (!secondaryAllowed && !DBIdentifier.isNull(sSecondary))
                 throw new MetaDataException(_loc.get("bad-second", fm));
         }
@@ -2175,7 +2191,7 @@ public class AnnotationPersistenceMappingParser
             efm = embed.getFieldMapping(over.name());
             if (efm == null)
                 throw new MetaDataException(_loc.get("embed-override-name",
-                    fm, over.name()));
+                        fm, over.name()));
             populate(efm, over);
         }
 
@@ -2195,8 +2211,8 @@ public class AnnotationPersistenceMappingParser
      * Parse embedded info for the given mapping.
      */
     private void parseEmbeddedMapping(ValueMapping vm,
-        DBIdentifier nullIndicatorAttribute, DBIdentifier nullIndicatorColumn,
-        XMappingOverride[] overrides) {
+            DBIdentifier nullIndicatorAttribute, DBIdentifier nullIndicatorColumn,
+            XMappingOverride[] overrides) {
         ClassMapping embed = vm.getEmbeddedMapping();
         if (embed == null)
             throw new MetaDataException(_loc.get("not-embedded", vm));
@@ -2206,7 +2222,7 @@ public class AnnotationPersistenceMappingParser
             efm = embed.getFieldMapping(over.name());
             if (efm == null)
                 throw new MetaDataException(_loc.get("embed-override-name",
-                    vm, over.name()));
+                        vm, over.name()));
             populate(efm, over);
         }
 
@@ -2256,7 +2272,7 @@ public class AnnotationPersistenceMappingParser
         //ctbl.catalog()
         parseJoinColumns(fm, fm.getMappingInfo(), false, ctbl.joinColumns());
         addUniqueConstraints(info.getTableIdentifier().getName(), fm.getDefiningMetaData(),
-            info, ctbl.uniqueConstraints());
+                info, ctbl.uniqueConstraints());
     }
 
     /**
@@ -2301,7 +2317,7 @@ public class AnnotationPersistenceMappingParser
      * Parse @ElementJoinColumn(s).
      */
     protected void parseElementJoinColumns(FieldMapping fm,
-        ElementJoinColumn... joins) {
+            ElementJoinColumn... joins) {
         if (joins.length == 0)
             return;
 
@@ -2329,9 +2345,9 @@ public class AnnotationPersistenceMappingParser
             col.setTargetField(join.referencedAttributeName());
         col.setNotNull(!join.nullable());
         col.setFlag (Column.FLAG_UNINSERTABLE, !join.insertable ());
-		col.setFlag (Column.FLAG_UNUPDATABLE, !join.updatable ());
-		return col;
-	}
+        col.setFlag (Column.FLAG_UNUPDATABLE, !join.updatable ());
+        return col;
+    }
 
     /**
      * Parse @MapKeyColumn.
@@ -2352,7 +2368,7 @@ public class AnnotationPersistenceMappingParser
      * Setup the given column with information from the given annotation.
      */
     private void setupMapKeyColumn(FieldMapping fm, Column col,
-        MapKeyColumn anno) {
+            MapKeyColumn anno) {
         if (!StringUtil.isEmpty(anno.name())) {
             col.setIdentifier(DBIdentifier.newColumn(anno.name(), delimit()));
         }
@@ -2377,7 +2393,7 @@ public class AnnotationPersistenceMappingParser
      * unique attribute of the column
      */
     protected void setMapKeyColumn(FieldMapping fm, MappingInfo info,
-        Column col, int unique) {
+            Column col, int unique) {
         List<Column> cols = new ArrayList<>();
         cols.add(col);
         info.setColumns(cols);

--- a/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/jdbc/annotations/EntityWithIndexColumnNames.java
+++ b/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/jdbc/annotations/EntityWithIndexColumnNames.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.openjpa.persistence.jdbc.annotations;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import org.apache.openjpa.persistence.jdbc.Index;
+
+/**
+ * Test entity for verifying that the {@code columnNames} attribute of the
+ * OpenJPA-specific {@link Index} annotation is correctly applied when placed
+ * at the field level.
+ */
+@Entity
+@Table(name = "IDX_COL_NAMES_ENTITY")
+public class EntityWithIndexColumnNames {
+
+    @Id
+    @Column(name = "PK")
+    private Long pk;
+
+    @Column(name = "COL_A")
+    @Index(name = "idx_col_a_b", columnNames = {"COL_A", "COL_B"})
+    private String colA;
+
+    @Column(name = "COL_B")
+    private String colB;
+
+    public Long getPk() {
+        return pk;
+    }
+
+    public void setPk(Long pk) {
+        this.pk = pk;
+    }
+
+    public String getColA() {
+        return colA;
+    }
+
+    public void setColA(String colA) {
+        this.colA = colA;
+    }
+
+    public String getColB() {
+        return colB;
+    }
+
+    public void setColB(String colB) {
+        this.colB = colB;
+    }
+}

--- a/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/jdbc/annotations/TestIndexColumnNames.java
+++ b/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/jdbc/annotations/TestIndexColumnNames.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.openjpa.persistence.jdbc.annotations;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.openjpa.jdbc.meta.ClassMapping;
+import org.apache.openjpa.jdbc.meta.FieldMapping;
+import org.apache.openjpa.jdbc.schema.Column;
+import org.apache.openjpa.jdbc.schema.Index;
+import org.apache.openjpa.persistence.JPAFacadeHelper;
+import org.apache.openjpa.persistence.test.SingleEMFTestCase;
+import org.junit.Test;
+
+/**
+ * Regression test for the bug where the {@code columnNames} attribute of the
+ * OpenJPA-specific field-level {@link org.apache.openjpa.persistence.jdbc.Index}
+ * annotation was silently ignored during annotation parsing.
+ *
+ * <p>Root cause: {@code AnnotationPersistenceMappingParser.parseIndex(MappingInfo, Index)}
+ * called the internal overload without passing {@code idx.columnNames()}, so the
+ * specified column names were never added to the schema {@code Index} object.</p>
+ */
+public class TestIndexColumnNames extends SingleEMFTestCase {
+
+    private ClassMapping _mapping;
+
+    @Override
+    public void setUp() {
+        setUp(EntityWithIndexColumnNames.class, CLEAR_TABLES);
+        emf.createEntityManager().close();
+        _mapping = (ClassMapping) JPAFacadeHelper.getMetaData(emf, EntityWithIndexColumnNames.class);
+    }
+
+    @Test
+    public void testFieldIndexColumnNamesAreApplied() {
+        FieldMapping fm = _mapping.getFieldMapping("colA");
+        assertNotNull("Field mapping for 'colA' must exist", fm);
+
+        Index idx = fm.getValueIndex();
+        assertNotNull("@Index on field 'colA' must create a schema index", idx);
+
+        Column[] columns = idx.getColumns();
+        assertTrue(
+                "Index defined with columnNames must contain at least one explicit column; "
+                + "before the fix, columnNames was ignored and the column list was empty",
+                columns.length > 0);
+
+        Set<String> colNames = Arrays.stream(columns)
+                .map(c -> c.getIdentifier().getName())
+                .collect(Collectors.toSet());
+        assertTrue("Index must contain COL_A (listed in columnNames)", colNames.contains("COL_A"));
+        assertTrue("Index must contain COL_B (listed in columnNames)", colNames.contains("COL_B"));
+    }
+}


### PR DESCRIPTION
## Fix: `@Index(columnNames)` at field level is silently ignored

### Problem

The OpenJPA-specific `@Index` annotation (`org.apache.openjpa.persistence.jdbc.Index`) supports a `columnNames` attribute that allows explicitly defining which columns should be included in a database index when the annotation is placed on a field or method. However, these column names were **silently ignored** during annotation parsing.

**Root cause:** `AnnotationPersistenceMappingParser.parseIndex(MappingInfo, Index)` called an internal overload passing only `name`, `enabled`, and `unique` — `idx.columnNames()` was never forwarded:

```java
// Before — columnNames dropped on the floor:
private void parseIndex(MappingInfo info, Index idx) {
    parseIndex(info, idx.name(), idx.enabled(), idx.unique());
}
```

As a result, any entity using `@Index(columnNames = {"COL_A", "COL_B"})` at the field level would get a schema index with no explicitly defined columns.

### Fix

- `parseIndex(MappingInfo, Index)` now passes `idx.columnNames()` to a new overload.
- New method `parseIndex(MappingInfo, String, boolean, boolean, String[])` creates `Column` objects from the provided names and adds them to the `Index` schema object.
- The existing `protected` 4-parameter overload delegates to the new method with `null` column names, preserving backwards compatibility for subclasses.

### Testing

Added a regression test that verifies the fix end-to-end:

- **`EntityWithIndexColumnNames`** — test entity with `@Index(name="idx_col_a_b", columnNames={"COL_A","COL_B"})` on a field.
- **`TestIndexColumnNames#testFieldIndexColumnNamesAreApplied`** — asserts that after full mapping resolution the schema index contains both explicitly named columns. The test fails without the fix (`getColumns().length == 0`) and passes with it.

### Changed Files

| File | Change |
|---|---|
| `AnnotationPersistenceMappingParser.java` | Bug fix + whitespace/indentation cleanup |
| `EntityWithIndexColumnNames.java` | New test entity |
| `TestIndexColumnNames.java` | New regression test |