### PR TITLE
[OPENJPA-2987] Restore externalized-parameter assertions

### DIFF
--- a/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/jdbc/sqlcache/TestExternalizedParameter.java
+++ b/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/jdbc/sqlcache/TestExternalizedParameter.java
@@ -18,7 +18,9 @@
  */
 package org.apache.openjpa.persistence.jdbc.sqlcache;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import jakarta.persistence.EntityManager;
@@ -29,11 +31,18 @@ import org.apache.openjpa.kernel.exps.QueryExpressions;
 import org.apache.openjpa.lib.rop.ResultList;
 import org.apache.openjpa.meta.FieldMetaData;
 import org.apache.openjpa.persistence.OpenJPAPersistence;
+import org.apache.openjpa.persistence.QueryImpl;
 
 import junit.framework.TestCase;
 
 /**
  * Tests that we can detect if a query is using query parameters for fields whose values are externalized.
+ * <p>
+ * Such queries can not be reparameterized and are therefore excluded from the prepared query cache. The
+ * detection operates on the {@link QueryExpressions} that are attached as a user object to the
+ * {@link ResultList} produced by the kernel query. Since JPA 3.2 the facade
+ * {@link jakarta.persistence.Query#getResultList()} returns a mutable copy of that result rather than the
+ * {@code ResultList} itself, so the tests execute the kernel query directly to get hold of the expressions.
  *
  * @author Pinaki Poddar
  *
@@ -56,44 +65,61 @@ public class TestExternalizedParameter extends TestCase {
         }
     }
 
-    /**
-     * Verifies that a query with a non-externalized parameter executes
-     * correctly.
-     */
     public void testNoFalseAlarmOnExternalizedParameterDetection() {
         String jpql = "select b from Book b where b.title=:title";
         EntityManager em = emf.createEntityManager();
-        List<?> result = em.createQuery(jpql)
-                .setParameter("title","XYZ")
-                .getResultList();
-        assertNotNull(result);
+        Map<String, Object> params = new HashMap<>();
+        params.put("title", "XYZ");
+
+        QueryExpressions[] exps = getExpressions(execute(em, jpql, params));
+        assertNotNull(exps);
+
+        assertFalse(isUsingExternalizedParameter(exps[0]));
     }
 
-    /**
-     * Verifies that a query with an externalized parameter (token maps
-     * to an enum via ExternalValues) executes correctly.
-     */
     public void testCanDetectExternalizedSingleParameterValue() {
         String jpql = "select b from Book b where b.token=:token";
         EntityManager em = emf.createEntityManager();
-        List<?> result = em.createQuery(jpql)
-                .setParameter("token","MEDIUM")
-                .getResultList();
-        assertNotNull(result);
+        Map<String, Object> params = new HashMap<>();
+        params.put("token", "MEDIUM");
+
+        QueryExpressions[] exps = getExpressions(execute(em, jpql, params));
+        assertNotNull(exps);
+
+        assertTrue(isUsingExternalizedParameter(exps[0]));
     }
 
-    /**
-     * Verifies that a query mixing externalized and non-externalized
-     * parameters executes correctly.
-     */
     public void testCanDetectExternalizedMixedParameterValue() {
         String jpql = "select b from Book b where b.token=:token and b.title = :title";
         EntityManager em = emf.createEntityManager();
-        List<?> result = em.createQuery(jpql)
-                .setParameter("token","MEDIUM")
-                .setParameter("title", "LARGE")
-                .getResultList();
-        assertNotNull(result);
+        Map<String, Object> params = new HashMap<>();
+        params.put("token", "MEDIUM");
+        params.put("title", "LARGE");
+
+        QueryExpressions[] exps = getExpressions(execute(em, jpql, params));
+        assertNotNull(exps);
+
+        assertTrue(isUsingExternalizedParameter(exps[0]));
+    }
+
+    /**
+     * Executes the given JPQL on the kernel query to get hold of the raw {@link ResultList}.
+     */
+    Object execute(EntityManager em, String jpql, Map<String, Object> params) {
+        QueryImpl<?> query = (QueryImpl<?>) em.createQuery(jpql);
+        return query.getDelegate().execute(params);
+    }
+
+    public QueryExpressions[] getExpressions(Object result) {
+        if (!(result instanceof ResultList))
+            return null;
+        Object userObject = ((ResultList<?>)result).getUserObject();
+        if (userObject == null || !userObject.getClass().isArray() || ((Object[])userObject).length != 2)
+            return null;
+        Object executor = ((Object[])userObject)[1];
+        if (!(executor instanceof StoreQuery.Executor))
+            return null;
+        return ((StoreQuery.Executor)executor).getQueryExpressions();
     }
 
     boolean isUsingExternalizedParameter(QueryExpressions exp) {


### PR DESCRIPTION
Follow-up on https://github.com/apache/openjpa/pull/144#discussion_r3683006222 (OPENJPA-2987).

### Answer to the review question

Externalized-parameter detection was **not** removed. `PreparedQueryImpl.extractSelectExecutor()` still calls `isUsingExternalizedParameter(...)` and excludes such queries from the prepared query cache. With trace logging enabled:

```
Query "select b from Book b where b.token=:token" is removed from cache excluded permanently.
... is not cached because some parameterized field values are externalized.
```

What broke was only the *test's access* to the expressions: JPA 3.2 requires a mutable `getResultList()`, so `org.apache.openjpa.persistence.QueryImpl.getResultList()` now returns `new ArrayList<>(delegate)` and the `(ResultList) result` cast in the old `getExpressions()` helper no longer works. The cache itself is unaffected, since `postExecute()` still receives the raw `ResultList`.

### Change

`TestExternalizedParameter` gets its original assertions back:

- `getExpressions(...)` helper restored
- `assertFalse(...)` / `assertTrue(isUsingExternalizedParameter(exps[0]))` restored in place of the no-op `assertNotNull(getResultList())`
- the `ResultList` is obtained by executing the kernel query directly (`((QueryImpl<?>) em.createQuery(jpql)).getDelegate().execute(params)`) instead of through the JPA facade

### Test

`mvn -pl openjpa-persistence-jdbc -Dtest=TestExternalizedParameter test` -> Tests run: 3, Failures: 0, Errors: 0.

### Note

While looking for a cache-level assertion instead: `PreparedQueryCacheImpl.isExcluded(id)` only matches user-supplied exclusion *patterns*. Per-query exclusions are stored in `_uncachables` and are only observable via `isCachable(id) == FALSE`, with no accessor for the exclusion reason. Since every `Book` query is uncachable anyway (eager `@ManyToMany` -> multiple SQL statements), that route cannot distinguish an externalized-parameter exclusion from any other, so the kernel-level assertion is the one that actually discriminates.