### PR TITLE
[OPENJPA-2957] Resolve embeddables through the metadata repository instead of annotation names

### DIFF
--- a/openjpa-kernel/src/main/java/org/apache/openjpa/kernel/exps/AbstractExpressionBuilder.java
+++ b/openjpa-kernel/src/main/java/org/apache/openjpa/kernel/exps/AbstractExpressionBuilder.java
@@ -305,8 +305,7 @@ public abstract class AbstractExpressionBuilder {
             meta = fmd.getEmbeddedMetaData();
         else
             meta = fmd.getDeclaredTypeMetaData();
-        if (meta == null && fmd.isEmbedded()
-            && !hasEmbeddableAnnotation(fmd.getDeclaredType())) {
+        if (meta == null && fmd.isEmbedded() && !isEmbeddable(fmd)) {
             // Non-@Embeddable @IdClass field inside @EmbeddedId (JPA 2.4.1.3
             // ex2b). Resolve via the @MapsId @ManyToOne target entity.
             meta = resolveMapsIdTargetMeta(fmd);
@@ -352,18 +351,16 @@ public abstract class AbstractExpressionBuilder {
     }
 
     /**
-     * Checks whether a class has an @Embeddable annotation via reflection.
-     * Uses annotation simple name to avoid compile-time dependency on
-     * jakarta.persistence.
+     * Whether the declared type of the given field is known to the metadata
+     * repository as an embeddable. Asking the repository rather than the type's
+     * annotations also covers embeddables that are declared in orm.xml only.
      */
-    private static boolean hasEmbeddableAnnotation(Class<?> type) {
-        if (type == null) return false;
-        for (java.lang.annotation.Annotation ann : type.getAnnotations()) {
-            if ("Embeddable".equals(ann.annotationType().getSimpleName())) {
-                return true;
-            }
-        }
-        return false;
+    private static boolean isEmbeddable(FieldMetaData fmd) {
+        Class<?> type = fmd.getDeclaredType();
+        if (type == null)
+            return false;
+        ClassMetaData typeMeta = fmd.getRepository().getMetaData(type, null, false);
+        return typeMeta != null && typeMeta.isEmbeddable();
     }
 
     /**


### PR DESCRIPTION
Replaces the simple-name annotation scan in `AbstractExpressionBuilder.hasEmbeddableAnnotation` with a repository lookup, as suggested in https://issues.apache.org/jira/browse/OPENJPA-2957. `ClassMetaData.isEmbeddable()` is set by both the annotation and the XML parser, so it also covers embeddables declared only in `orm.xml` and no longer matches any annotation that happens to be called `Embeddable`.

Note that `fmd.getEmbeddedMetaData()` cannot be used directly here: the guard is only reached when that call already returned `null`, so the check has to ask about the declared type instead. This is a robustness fix rather than a behavioural one — I could not construct a case where the old check produced a wrong answer, since the branch is only reachable for an `@EmbeddedId` field whose embedded metadata is absent. `openjpa.persistence.embed.**` (89 tests, including the XML-mapped ones) and the `TestDerivedIdEx2b` / `TestUnenhancedDerivedIdEx2b` regression tests for the original 2.4.1.3 ex2b fix are green.