### PR TITLE
[OPENJPA-2959] Do not drop tables of types excluded from schema synchronization

### DIFF
--- a/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/kernel/JDBCBrokerFactory.java
+++ b/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/kernel/JDBCBrokerFactory.java
@@ -26,25 +26,18 @@ import static org.apache.openjpa.conf.SchemaGenerationSource.METADATA_THEN_SCRIP
 import static org.apache.openjpa.conf.SchemaGenerationSource.SCRIPT;
 import static org.apache.openjpa.conf.SchemaGenerationSource.SCRIPT_THEN_METADATA;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.sql.DataSource;
-
 import org.apache.openjpa.conf.SchemaGenerationSource;
 import org.apache.openjpa.jdbc.conf.JDBCConfiguration;
 import org.apache.openjpa.jdbc.conf.JDBCConfigurationImpl;
-import org.apache.openjpa.jdbc.meta.ClassMapping;
 import org.apache.openjpa.jdbc.meta.MappingRepository;
 import org.apache.openjpa.jdbc.meta.MappingTool;
 import org.apache.openjpa.jdbc.schema.SchemaTool;
-import org.apache.openjpa.lib.log.Log;
 import org.apache.openjpa.kernel.AbstractBrokerFactory;
 import org.apache.openjpa.kernel.Bootstrap;
 import org.apache.openjpa.kernel.Broker;
@@ -258,75 +251,11 @@ public class JDBCBrokerFactory extends AbstractBrokerFactory {
         }
         tool.record();
 
-        // For excluded types, actively drop their tables if they exist
-        // in the database. This ensures tables from previous runs (before
-        // the type was excluded) don't persist and cause operations to
-        // succeed silently instead of throwing the expected RuntimeException.
-        if (!excludeTypes.isEmpty()) {
-            dropExcludedTypeTables(conf, repo, excludeTypes, loader);
-        }
-
         return true; // todo: check?
     }
 
     protected boolean synchronizeMappings(ClassLoader loader) {
         return synchronizeMappings(loader, (JDBCConfiguration) getConfiguration());
-    }
-
-    /**
-     * Drop tables for entity types that are excluded from schema
-     * synchronization. This ensures that tables left over from a previous
-     * run (before the type was excluded) are removed so that SQL operations
-     * against them will fail as expected.
-     */
-    private void dropExcludedTypeTables(JDBCConfiguration conf,
-            MappingRepository repo, Set<String> excludeTypes,
-            ClassLoader loader) {
-        Log log = conf.getLog("openjpa.jdbc.Schema");
-        DataSource ds = conf.getDataSource2(null);
-        for (String typeName : excludeTypes) {
-            try {
-                ClassLoader clsLoader = conf.getClassResolverInstance()
-                    .getClassLoader(getClass(), loader);
-                Class<?> cls = Class.forName(typeName, true, clsLoader);
-
-                // Use the mapping repository to determine the table name
-                ClassMapping mapping = repo.getMapping(cls, clsLoader, false);
-                if (mapping == null || mapping.getTable() == null) {
-                    continue;
-                }
-                String tableName =
-                    mapping.getTable().getFullIdentifier().getName();
-
-                Connection conn = ds.getConnection();
-                try {
-                    conn.setAutoCommit(true);
-                    Statement stmt = conn.createStatement();
-                    try {
-                        stmt.executeUpdate("DROP TABLE " + tableName);
-                        if (log.isTraceEnabled()) {
-                            log.trace("Dropped excluded type table: "
-                                + tableName);
-                        }
-                    } catch (SQLException sqle) {
-                        // Table may not exist; ignore silently
-                        if (log.isTraceEnabled()) {
-                            log.trace("Could not drop excluded type table "
-                                + tableName + ": " + sqle.getMessage());
-                        }
-                    } finally {
-                        stmt.close();
-                    }
-                } finally {
-                    conn.close();
-                }
-            } catch (Exception e) {
-                if (log.isTraceEnabled()) {
-                    log.trace("Error dropping table for excluded type "
-                        + typeName + ": " + e.getMessage());
-                }
-            }
-        }
     }
 
     private void mapSchemaGenerationToSynchronizeMappings(JDBCConfiguration conf) {


### PR DESCRIPTION
Removes `JDBCBrokerFactory.dropExcludedTypeTables` as suggested in https://issues.apache.org/jira/browse/OPENJPA-2959. The review was right on both counts: it built raw `"DROP TABLE " + name` SQL without `toDBName`/quoting or CASCADE handling, and it swallowed every failure at trace level — but the real problem is that dropping a user table because its type was excluded from synchronization is destructive, and an excluded type may well be a table managed outside OpenJPA on purpose.

It was also test-driven rather than a feature: `git log` traces it to 682623b6d, whose message says it exists "so operations against non-existent entity tables fail as expected", and the only consumer of `SyncMappingsExcludeTypes` anywhere in the tree is `tck32-openjpa-profile.xml` for `entityManager2.DoesNotExist`. Excluding the type from schema creation — the part that is kept — is the actual feature; the drop only papered over a table left behind by an earlier run against a reused database.

Six imports become unused and were removed with it. No test in the tree exercises `ExcludeTypes`, and the `persistence.schema.**` / `persistence.jdbc.schema.**` selection returns exactly the same 5 failures / 28 errors on this branch as on master (all pre-existing, unrelated harness issues). 